### PR TITLE
feat(docs): enhance tool documentation with metadata and status tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,20 @@ mise-completions-sync list
 mise-completions-sync clean
 ```
 
+## Updating
+
+To update to the latest version:
+
+```bash
+mise upgrade github:alltuner/mise-completions-sync
+```
+
+Or to pin a specific version:
+
+```bash
+mise use -g github:alltuner/mise-completions-sync@0.3.0
+```
+
 ## Automatic Sync
 
 Set up a mise hook to sync completions when tools are installed:

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -1,0 +1,114 @@
+# Tool Support Status
+
+This document tracks shell completion support status for tools in mise's registry.
+Use this to identify tools that could be added to mise-completions-sync.
+
+## Supported Tools
+
+Currently **77 tools** have completion support.
+
+See [docs/tools.md](docs/tools.md) for the full list with shell support details.
+
+## Pending Tools (Candidates)
+
+These tools are in mise's registry but not yet supported. They may have completion support.
+
+| Tool | Description | Status |
+|------|-------------|--------|
+| [1password](https://github.com/1password/cli) | Password manager developed by AgileBits Inc | Needs testing |
+| aapt2 | Android Asset Packaging Tool (aapt) | Needs testing |
+| [act](https://github.com/nektos/act) | Run your GitHub Actions locally | Needs testing |
+| [action-validator](https://github.com/mpalmer/action-validator) | Tool to validate GitHub Action and Workflow YAM... | Needs testing |
+| [actionlint](https://github.com/rhysd/actionlint) | :octocat: Static checker for GitHub Actions wor... | Needs testing |
+| [adr-tools](https://github.com/npryce/adr-tools) | Command-line tools for working with Architectur... | Needs testing |
+| ag | The Silver Searcher: A code searching tool simi... | Needs testing |
+| [age](https://github.com/FiloSottile/age) | A simple, modern and secure encryption tool (an... | Needs testing |
+| age-plugin-yubikey | age-plugin-yubikey is a plugin for age clients ... | Needs testing |
+| [agebox](https://github.com/slok/agebox) | Age based repository file encryption gitops tool | Needs testing |
+| [aichat](https://github.com/sigoden/aichat) | Use GPT-4(V), Gemini, LocalAI, Ollama and other... | Needs testing |
+| [aks-engine](https://github.com/Azure/aks-engine) | AKS Engine deploys and manages Kubernetes clust... | Needs testing |
+| allure | Allure Report is a popular open source tool for... | Needs testing |
+| allurectl | allurectl is the command line wrapper of Allure... | Needs testing |
+| [alp](https://github.com/tkuchiki/alp) | Access Log Profiler | Needs testing |
+| amass | In-depth attack surface mapping and asset disco... | Needs testing |
+| [amazon-ecr-credential-helper](https://github.com/awslabs/amazon-ecr-credential-helper) | Automatically gets credentials for Amazon ECR o... | Needs testing |
+| [amazon-ecs-cli](https://github.com/aws/amazon-ecs-cli) | The Amazon ECS CLI enables users to run their a... | Needs testing |
+| amp | An agentic coding tool built by Sourcegraph | Needs testing |
+| android-sdk | Android Command-line tools | Needs testing |
+| ansible | ansible python package contains the core runtim... | Needs testing |
+| ansible-core | ansible-core python package contains the core r... | Needs testing |
+| ant | Apache Ant is a Java library and command-line t... | Needs testing |
+| [apko](https://github.com/chainguard-dev/apko) | Build OCI images from APK packages directly wit... | Needs testing |
+| apollo-ios | Apollo iOS Code Generation | Needs testing |
+| apollo-router | A configurable, high-performance routing runtim... | Needs testing |
+| apollo-rover | The CLI for Apollo GraphOS | Needs testing |
+| aqua | Declarative CLI Version manager written in Go. ... | Needs testing |
+| [arduino](https://github.com/arduino/arduino-cli) | Arduino command line tool | Needs testing |
+| argc | A Bash CLI framework, also a Bash command runner | Needs testing |
+| [argo](https://github.com/argoproj/argo-workflows) | Argo Workflows CLI. Workflow engine for Kubernetes | Needs testing |
+| [argo-rollouts](https://github.com/argoproj/argo-rollouts) | Progressive Delivery for Kubernetes | Needs testing |
+| asciidoctorj | AsciidoctorJ is the official library for runnin... | Needs testing |
+| assh | make your ssh client smarter | Needs testing |
+| [ast-grep](https://github.com/ast-grep/ast-grep) | A CLI tool for code structural search, lint and... | Needs testing |
+| astro | CLI that makes it easy to create, test and depl... | Needs testing |
+| [atlas](https://github.com/ariga/atlas) | A modern tool for managing database schemas | Needs testing |
+| [atmos](https://github.com/cloudposse/atmos) | Workflow automation tool for DevOps. Keep confi... | Needs testing |
+| auto-doc | Github action that turns your reusable workflow... | Needs testing |
+| aws-amplify | The AWS Amplify CLI is a toolchain for simplify... | Needs testing |
+| [aws-cli](https://github.com/aws/aws-cli) | The AWS Command Line Interface (AWS CLI v2) is ... | Needs testing |
+| [aws-copilot](https://github.com/aws/copilot-cli) | The AWS Copilot CLI is a tool for developers to... | Needs testing |
+| [aws-iam-authenticator](https://github.com/kubernetes-sigs/aws-iam-authenticator) | A tool to use AWS IAM credentials to authentica... | Needs testing |
+| [aws-nuke](https://github.com/ekristen/aws-nuke) | Remove all the resources from an AWS account | Needs testing |
+| [aws-sam](https://github.com/aws/aws-sam-cli) | CLI tool to build, test, debug, and deploy Serv... | Needs testing |
+| [aws-sso](https://github.com/synfinatic/aws-sso-cli) | A powerful tool for using AWS Identity Center f... | Needs testing |
+| [aws-vault](https://github.com/ByteNess/aws-vault) | A vault for securely storing and accessing AWS ... | Needs testing |
+| awscli-local | This package provides the awslocal command, whi... | Needs testing |
+| awsebcli | The AWS Elastic Beanstalk Command Line Interfac... | Needs testing |
+| awsls | A list command for AWS resources | Needs testing |
+
+*...and 832 more tools in mise registry*
+
+## Tools Without Completion Support
+
+These tools have been tested and confirmed to NOT output shell completion scripts:
+
+- **air**: Live reload for Go apps
+- **aws**: The AWS Command Line Interface (AWS CLI v2) is ...
+- **biome**: A toolchain for web projects, aimed to provide ...
+- **consul**: Consul is a distributed, highly available, and ...
+- **croc**: Easily and securely send things from one comput...
+- **dust**: A more intuitive version of du in rust
+- **evans**: Evans: more expressive universal gRPC client
+- **eza**: A modern, maintained replacement for ls
+- **nomad**: Nomad is an easy-to-use, flexible, and performa...
+- **terraform**: Terraform enables you to safely and predictably...
+- **tokei**: Count your code, quickly
+- **vault**: A tool for secrets management, encryption as a ...
+- **wrangler**: A command line tool for building Cloudflare Wor...
+- **yarn**: Yarn is a package manager that doubles down as ...
+
+## How to Add a Tool
+
+1. Check if the tool supports shell completions:
+   ```bash
+   mise x <tool> -- <tool> completion --help
+   mise x <tool> -- <tool> --help | grep -i complet
+   ```
+
+2. Find the correct completion command pattern
+
+3. Add entry to `registry.toml`:
+   ```toml
+   # If it matches an existing pattern:
+   newtool = "standard"  # for: newtool completion <shell>
+
+   # Or with explicit commands:
+   newtool = { zsh = "newtool completions zsh", bash = "newtool completions bash" }
+   ```
+
+4. Test the entry:
+   ```bash
+   uv run scripts/validate-registry.py --installed-only
+   ```
+
+5. Submit a PR

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,6 +58,20 @@ Add to `~/.config/fish/config.fish`:
 set -gx fish_complete_path $fish_complete_path ~/.local/share/mise-completions/fish
 ```
 
+## Updating
+
+To update to the latest version:
+
+```bash
+mise upgrade github:alltuner/mise-completions-sync
+```
+
+Or to pin a specific version:
+
+```bash
+mise use -g github:alltuner/mise-completions-sync@0.3.0
+```
+
 ## Automatic Sync
 
 Set up a mise hook to automatically sync completions when tools are installed:

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,99 +1,99 @@
 # Supported Tools
 
-The following tools have completion support in mise-completions-sync.
+The following tools have shell completion support in mise-completions-sync.
 
-| Tool | ZSH | Bash | Fish |
-|------|-----|------|------|
-| air | ✓ | ✓ | ✓ |
-| argocd | ✓ | ✓ | ✓ |
-| atuin | ✓ | ✓ | ✓ |
-| aws | ✓ | ✓ |  |
-| bat | ✓ | ✓ | ✓ |
-| biome | ✓ | ✓ | ✓ |
-| bun | ✓ |  |  |
-| cargo | ✓ | ✓ | ✓ |
-| chezmoi | ✓ | ✓ | ✓ |
-| consul | ✓ | ✓ |  |
-| cosign | ✓ | ✓ | ✓ |
-| croc | ✓ | ✓ | ✓ |
-| cue | ✓ | ✓ | ✓ |
-| dagger | ✓ | ✓ | ✓ |
-| delta | ✓ | ✓ | ✓ |
-| deno | ✓ | ✓ | ✓ |
-| docker | ✓ | ✓ | ✓ |
-| doctl | ✓ | ✓ | ✓ |
-| dust | ✓ | ✓ | ✓ |
-| evans | ✓ | ✓ | ✓ |
-| eza | ✓ | ✓ | ✓ |
-| fd | ✓ | ✓ | ✓ |
-| flux | ✓ | ✓ | ✓ |
-| flyctl | ✓ | ✓ | ✓ |
-| fzf | ✓ | ✓ | ✓ |
-| gcloud | ✓ | ✓ |  |
-| gh | ✓ | ✓ | ✓ |
-| gitu | ✓ | ✓ | ✓ |
-| gitui | ✓ | ✓ | ✓ |
-| glab | ✓ | ✓ | ✓ |
-| golangci-lint | ✓ | ✓ | ✓ |
-| goreleaser | ✓ | ✓ | ✓ |
-| grpcurl | ✓ | ✓ | ✓ |
-| helm | ✓ | ✓ | ✓ |
-| hugo | ✓ | ✓ | ✓ |
-| hyperfine | ✓ | ✓ | ✓ |
-| istioctl | ✓ | ✓ | ✓ |
-| just | ✓ | ✓ | ✓ |
-| k3d | ✓ | ✓ | ✓ |
-| k9s | ✓ | ✓ | ✓ |
-| kind | ✓ | ✓ | ✓ |
-| ko | ✓ | ✓ | ✓ |
-| krew | ✓ | ✓ | ✓ |
-| kubectl | ✓ | ✓ | ✓ |
-| kubectx | ✓ | ✓ |  |
-| kubeseal | ✓ | ✓ | ✓ |
-| kustomize | ✓ | ✓ | ✓ |
-| lazygit | ✓ | ✓ | ✓ |
-| lefthook | ✓ | ✓ | ✓ |
-| linkerd | ✓ | ✓ | ✓ |
-| mdbook | ✓ | ✓ | ✓ |
-| minikube | ✓ | ✓ | ✓ |
-| mise | ✓ | ✓ | ✓ |
-| mkcert | ✓ | ✓ | ✓ |
-| nerdctl | ✓ | ✓ | ✓ |
-| nix | ✓ | ✓ | ✓ |
-| nomad | ✓ | ✓ |  |
-| npm | ✓ | ✓ |  |
-| oc | ✓ | ✓ | ✓ |
-| oci | ✓ | ✓ | ✓ |
-| pipx | ✓ | ✓ |  |
-| pnpm | ✓ | ✓ |  |
-| podman | ✓ | ✓ | ✓ |
-| poetry | ✓ | ✓ | ✓ |
-| pulumi | ✓ | ✓ | ✓ |
-| restic | ✓ | ✓ | ✓ |
-| rg | ✓ | ✓ | ✓ |
-| ripgrep | ✓ | ✓ | ✓ |
-| ruff | ✓ | ✓ | ✓ |
-| rustup | ✓ | ✓ | ✓ |
-| saml2aws | ✓ | ✓ | ✓ |
-| skaffold | ✓ | ✓ | ✓ |
-| sops | ✓ | ✓ |  |
-| starship | ✓ | ✓ | ✓ |
-| step | ✓ | ✓ | ✓ |
-| stern | ✓ | ✓ | ✓ |
-| task | ✓ | ✓ | ✓ |
-| terraform | ✓ | ✓ |  |
-| tilt | ✓ | ✓ | ✓ |
-| tokei | ✓ | ✓ | ✓ |
-| trivy | ✓ | ✓ | ✓ |
-| ty | ✓ | ✓ | ✓ |
-| uv | ✓ | ✓ | ✓ |
-| vault | ✓ | ✓ |  |
-| velero | ✓ | ✓ | ✓ |
-| vercel | ✓ | ✓ |  |
-| wrangler | ✓ | ✓ |  |
-| xh | ✓ | ✓ | ✓ |
-| yarn | ✓ |  |  |
-| zellij | ✓ | ✓ | ✓ |
-| zoxide | ✓ | ✓ | ✓ |
+| Tool | Description | ZSH | Bash | Fish |
+|------|-------------|-----|------|------|
+| [argocd](https://github.com/argoproj/argo-cd) | Declarative continuous deployment for Kubernetes | ✓ | ✓ | ✓ |
+| [atuin](https://github.com/atuinsh/atuin) | ✨ Magical shell history | ✓ | ✓ | ✓ |
+| [bat](https://github.com/sharkdp/bat) | A cat(1) clone with wings | ✓ | ✓ | ✓ |
+| bun | Bun is a fast JavaScript all-in-one toolkit | ✓ |  |  |
+| cargo |  | ✓ | ✓ | ✓ |
+| [chezmoi](https://github.com/twpayne/chezmoi) | Manage your dotfiles across multiple diverse ma... | ✓ | ✓ | ✓ |
+| [cosign](https://github.com/sigstore/cosign) | Code signing and transparency for containers an... | ✓ | ✓ | ✓ |
+| [cue](https://github.com/cue-lang/cue) | The home of the CUE language! Validate and defi... | ✓ | ✓ | ✓ |
+| [dagger](https://github.com/dagger/dagger) | A portable devkit for CI/CD pipelines | ✓ | ✓ | ✓ |
+| [delta](https://github.com/dandavison/delta) | A syntax-highlighting pager for git, diff, and ... | ✓ | ✓ | ✓ |
+| deno | A modern runtime for JavaScript and TypeScript ... | ✓ | ✓ | ✓ |
+| docker |  | ✓ | ✓ | ✓ |
+| [doctl](https://github.com/digitalocean/doctl) | The official command line interface for the Dig... | ✓ | ✓ | ✓ |
+| [fd](https://github.com/sharkdp/fd) | A simple, fast and user-friendly alternative to... | ✓ | ✓ | ✓ |
+| flux |  | ✓ | ✓ | ✓ |
+| [flyctl](https://github.com/superfly/flyctl) | Command line tools for fly.io services | ✓ | ✓ | ✓ |
+| [fzf](https://github.com/junegunn/fzf) | :cherry_blossom: A command-line fuzzy finder | ✓ | ✓ | ✓ |
+| gcloud | GCloud CLI (Google Cloud SDK) | ✓ | ✓ |  |
+| [gh](https://github.com/cli/cli) | GitHub’s official command line tool | ✓ | ✓ | ✓ |
+| [gitu](https://github.com/altsem/gitu) | A TUI Git client inspired by Magit | ✓ | ✓ | ✓ |
+| [gitui](https://github.com/extrawurst/gitui) | Blazing 💥 fast terminal-ui for git written in rust | ✓ | ✓ | ✓ |
+| glab | gitlab cli | ✓ | ✓ | ✓ |
+| [golangci-lint](https://github.com/golangci/golangci-lint) | Fast linters Runner for Go | ✓ | ✓ | ✓ |
+| [goreleaser](https://github.com/goreleaser/goreleaser) | Deliver Go binaries as fast and easily as possible | ✓ | ✓ | ✓ |
+| [grpcurl](https://github.com/fullstorydev/grpcurl) | Like cURL, but for gRPC: Command-line tool for ... | ✓ | ✓ | ✓ |
+| [helm](https://github.com/helm/helm) | The Kubernetes Package Manager | ✓ | ✓ | ✓ |
+| [hugo](https://github.com/gohugoio/hugo) | The world’s fastest framework for building webs... | ✓ | ✓ | ✓ |
+| [hyperfine](https://github.com/sharkdp/hyperfine) | A command-line benchmarking tool | ✓ | ✓ | ✓ |
+| [istioctl](https://github.com/istio/istio) | Istio configuration command line utility for se... | ✓ | ✓ | ✓ |
+| [just](https://github.com/casey/just) | Just a command runner | ✓ | ✓ | ✓ |
+| [k3d](https://github.com/k3d-io/k3d) | Little helper to run CNCF's k3s in Docker | ✓ | ✓ | ✓ |
+| [k9s](https://github.com/derailed/k9s) | Kubernetes CLI To Manage Your Clusters In Style | ✓ | ✓ | ✓ |
+| [kind](https://github.com/kubernetes-sigs/kind) | Kubernetes IN Docker - local clusters for testi... | ✓ | ✓ | ✓ |
+| [ko](https://github.com/ko-build/ko) | Build and deploy Go applications on Kubernetes | ✓ | ✓ | ✓ |
+| [krew](https://github.com/kubernetes-sigs/krew) | Find and install kubectl plugins | ✓ | ✓ | ✓ |
+| [kubectl](https://github.com/kubernetes/kubernetes) | kubectl cli | ✓ | ✓ | ✓ |
+| [kubectx](https://github.com/ahmetb/kubectx) | Faster way to switch between clusters and names... | ✓ | ✓ |  |
+| [kubeseal](https://github.com/bitnami-labs/sealed-secrets) | A Kubernetes controller and tool for one-way en... | ✓ | ✓ | ✓ |
+| [kustomize](https://github.com/kubernetes-sigs/kustomize) | Customization of kubernetes YAML configurations | ✓ | ✓ | ✓ |
+| [lazygit](https://github.com/jesseduffield/lazygit) | simple terminal UI for git commands | ✓ | ✓ | ✓ |
+| [lefthook](https://github.com/evilmartians/lefthook) | Fast and powerful Git hooks manager for any typ... | ✓ | ✓ | ✓ |
+| [linkerd](https://github.com/linkerd/linkerd2) | Ultralight, security-first service mesh for Kub... | ✓ | ✓ | ✓ |
+| [mdbook](https://github.com/rust-lang/mdBook) | Create book from markdown files. Like Gitbook b... | ✓ | ✓ | ✓ |
+| [minikube](https://github.com/kubernetes/minikube) | Run Kubernetes locally | ✓ | ✓ | ✓ |
+| mise |  | ✓ | ✓ | ✓ |
+| [mkcert](https://github.com/FiloSottile/mkcert) | A simple zero-config tool to make locally trust... | ✓ | ✓ | ✓ |
+| [nerdctl](https://github.com/containerd/nerdctl) | contaiNERD CTL - Docker-compatible CLI for cont... | ✓ | ✓ | ✓ |
+| nix |  | ✓ | ✓ | ✓ |
+| npm | the package manager for JavaScript | ✓ | ✓ |  |
+| oc | OpenShift Client CLI (oc) | ✓ | ✓ | ✓ |
+| oci | Oracle Cloud Infrastructure CLI | ✓ | ✓ | ✓ |
+| [pipx](https://github.com/pypa/pipx) |  | ✓ | ✓ |  |
+| [pnpm](https://github.com/pnpm/pnpm) | Fast, disk space efficient package manager | ✓ | ✓ |  |
+| podman | Podman: A tool for managing OCI containers and ... | ✓ | ✓ | ✓ |
+| poetry | Python packaging and dependency management made... | ✓ | ✓ | ✓ |
+| [pulumi](https://github.com/pulumi/pulumi) | Pulumi - Infrastructure as Code in any programm... | ✓ | ✓ | ✓ |
+| [restic](https://github.com/restic/restic) | Fast, secure, efficient backup program | ✓ | ✓ | ✓ |
+| [rg](https://github.com/BurntSushi/ripgrep) | ripgrep recursively searches directories for a ... | ✓ | ✓ | ✓ |
+| [ripgrep](https://github.com/BurntSushi/ripgrep) | ripgrep recursively searches directories for a ... | ✓ | ✓ | ✓ |
+| [ruff](https://github.com/astral-sh/ruff) | An extremely fast Python linter and code format... | ✓ | ✓ | ✓ |
+| rustup |  | ✓ | ✓ | ✓ |
+| [saml2aws](https://github.com/Versent/saml2aws) | CLI tool which enables you to login and retriev... | ✓ | ✓ | ✓ |
+| [skaffold](https://github.com/GoogleContainerTools/skaffold) | Easy and Repeatable Kubernetes Development | ✓ | ✓ | ✓ |
+| [sops](https://github.com/getsops/sops) | Simple and flexible tool for managing secrets | ✓ | ✓ |  |
+| [starship](https://github.com/starship/starship) | The minimal, blazing-fast, and infinitely custo... | ✓ | ✓ | ✓ |
+| [step](https://github.com/smallstep/cli) | A zero trust swiss army knife for working with ... | ✓ | ✓ | ✓ |
+| [stern](https://github.com/stern/stern) | ⎈ Multi pod and container log tailing for Kuber... | ✓ | ✓ | ✓ |
+| [task](https://github.com/go-task/task) | A task runner / simpler Make alternative writte... | ✓ | ✓ | ✓ |
+| [tilt](https://github.com/tilt-dev/tilt) | Define your dev environment as code. For micros... | ✓ | ✓ | ✓ |
+| [trivy](https://github.com/aquasecurity/trivy) | Find vulnerabilities, misconfigurations, secret... | ✓ | ✓ | ✓ |
+| [ty](https://github.com/astral-sh/ty) | An extremely fast Python type checker and langu... | ✓ | ✓ | ✓ |
+| [uv](https://github.com/astral-sh/uv) | An extremely fast Python package installer and ... | ✓ | ✓ | ✓ |
+| [velero](https://github.com/vmware-tanzu/velero) | Backup and migrate Kubernetes applications and ... | ✓ | ✓ | ✓ |
+| vercel |  | ✓ | ✓ |  |
+| [xh](https://github.com/ducaale/xh) | Friendly and fast tool for sending HTTP requests | ✓ | ✓ | ✓ |
+| [zellij](https://github.com/zellij-org/zellij) | A terminal workspace with batteries included | ✓ | ✓ | ✓ |
+| [zoxide](https://github.com/ajeetdsouza/zoxide) | A smarter cd command. Supports all major shells | ✓ | ✓ | ✓ |
 
-**Total: 91 tools**
+**Total: 77 tools**
+
+## Shell Support Legend
+
+- **✓** = Full completion support
+- Empty = Not supported by the tool for this shell
+
+## Adding New Tools
+
+If a tool you use isn't listed:
+
+1. Check if the tool supports shell completions (`tool completion --help`)
+2. Add an entry to `registry.toml` using an existing pattern or explicit commands
+3. Test with `uv run scripts/validate-registry.py --installed-only`
+4. Submit a PR

--- a/mise.toml
+++ b/mise.toml
@@ -36,6 +36,10 @@ description = "Install pre-commit hooks"
 run = "uv run scripts/generate-tools-docs.py > docs/tools.md"
 description = "Generate tools documentation from registry"
 
+[tasks.docs-status]
+run = "uv run scripts/generate-tools-status.py > TOOLS.md"
+description = "Generate TOOLS.md with supported and pending tools"
+
 [tasks.validate-registry]
 run = "uv run scripts/validate-registry.py --installed-only"
 description = "Validate registry entries against installed tools"

--- a/scripts/generate-tools-status.py
+++ b/scripts/generate-tools-status.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+# ABOUTME: Generates TOOLS.md with supported and pending tools for tracking.
+# ABOUTME: Helps Claude Code sessions continue adding support for more tools.
+"""
+Generates TOOLS.md with supported and pending tool lists.
+
+Usage: uv run scripts/generate-tools-status.py > TOOLS.md
+"""
+
+import json
+import subprocess
+import tomllib
+from pathlib import Path
+
+# Tools known to NOT support shell completions (validated manually)
+NO_COMPLETION_SUPPORT = {
+    "air",
+    "aws",  # Uses runtime completer, not script generator
+    "biome",
+    "consul",  # HashiCorp autocomplete-install pattern
+    "croc",
+    "dust",
+    "evans",
+    "eza",
+    "nomad",  # HashiCorp autocomplete-install pattern
+    "terraform",  # HashiCorp autocomplete-install pattern
+    "tokei",
+    "vault",  # HashiCorp autocomplete-install pattern
+    "wrangler",
+    "yarn",  # Requires project context
+}
+
+# Common completion patterns to check
+COMPLETION_HINTS = [
+    "completion",
+    "completions",
+    "--completions",
+    "generate-completion",
+    "shell-completion",
+]
+
+
+def get_mise_registry() -> dict[str, dict]:
+    """Fetch tool metadata from mise's registry."""
+    result = subprocess.run(
+        ["mise", "registry", "--json"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return {}
+
+    try:
+        data = json.loads(result.stdout)
+        return {item["short"]: item for item in data}
+    except (json.JSONDecodeError, KeyError):
+        return {}
+
+
+def load_supported_tools() -> set[str]:
+    """Load tools from our registry.toml."""
+    registry_path = Path(__file__).parent.parent / "registry.toml"
+    with open(registry_path, "rb") as f:
+        registry = tomllib.load(f)
+    return set(registry.get("tools", {}).keys())
+
+
+def get_github_url(backends: list[str]) -> str | None:
+    """Extract GitHub URL from backend info if possible."""
+    for backend in backends:
+        if backend.startswith("aqua:"):
+            parts = backend.replace("aqua:", "").split("/")
+            if len(parts) >= 2:
+                return f"https://github.com/{parts[0]}/{parts[1]}"
+    return None
+
+
+def main():
+    supported = load_supported_tools()
+    mise_registry = get_mise_registry()
+
+    print("# Tool Support Status")
+    print()
+    print("This document tracks shell completion support status for tools in mise's registry.")
+    print("Use this to identify tools that could be added to mise-completions-sync.")
+    print()
+    print("## Supported Tools")
+    print()
+    print(f"Currently **{len(supported)} tools** have completion support.")
+    print()
+    print("See [docs/tools.md](docs/tools.md) for the full list with shell support details.")
+    print()
+
+    # Find candidate tools (popular tools that might have completions)
+    print("## Pending Tools (Candidates)")
+    print()
+    print("These tools are in mise's registry but not yet supported. They may have completion support.")
+    print()
+    print("| Tool | Description | Status |")
+    print("|------|-------------|--------|")
+
+    # Get all tools from mise registry, filter out supported and known-no-support
+    candidates = []
+    for tool, meta in sorted(mise_registry.items()):
+        if tool in supported:
+            continue
+        if tool in NO_COMPLETION_SUPPORT:
+            continue
+        # Skip aliases (tools that point to another tool)
+        if meta.get("aliases") and tool in meta.get("aliases", []):
+            continue
+
+        description = meta.get("description", "")
+        if len(description) > 50:
+            description = description[:47] + "..."
+
+        github_url = get_github_url(meta.get("backends", []))
+        tool_display = f"[{tool}]({github_url})" if github_url else tool
+
+        candidates.append((tool_display, description))
+
+    # Show first 50 candidates
+    for tool_display, description in candidates[:50]:
+        print(f"| {tool_display} | {description} | Needs testing |")
+
+    if len(candidates) > 50:
+        print()
+        print(f"*...and {len(candidates) - 50} more tools in mise registry*")
+
+    print()
+    print("## Tools Without Completion Support")
+    print()
+    print("These tools have been tested and confirmed to NOT output shell completion scripts:")
+    print()
+    for tool in sorted(NO_COMPLETION_SUPPORT):
+        meta = mise_registry.get(tool, {})
+        description = meta.get("description", "")
+        if len(description) > 50:
+            description = description[:47] + "..."
+        print(f"- **{tool}**: {description}")
+
+    print()
+    print("## How to Add a Tool")
+    print()
+    print("1. Check if the tool supports shell completions:")
+    print("   ```bash")
+    print("   mise x <tool> -- <tool> completion --help")
+    print("   mise x <tool> -- <tool> --help | grep -i complet")
+    print("   ```")
+    print()
+    print("2. Find the correct completion command pattern")
+    print()
+    print("3. Add entry to `registry.toml`:")
+    print("   ```toml")
+    print("   # If it matches an existing pattern:")
+    print('   newtool = "standard"  # for: newtool completion <shell>')
+    print()
+    print("   # Or with explicit commands:")
+    print('   newtool = { zsh = "newtool completions zsh", bash = "newtool completions bash" }')
+    print("   ```")
+    print()
+    print("4. Test the entry:")
+    print("   ```bash")
+    print("   uv run scripts/validate-registry.py --installed-only")
+    print("   ```")
+    print()
+    print("5. Submit a PR")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Enhanced `generate-tools-docs.py` to fetch descriptions and GitHub links from mise's registry
- Created `TOOLS.md` to track supported (77) and pending tools for future Claude Code sessions
- Added `generate-tools-status.py` script for maintaining TOOLS.md
- Added update instructions to README and docs site

## Changes
1. **Richer docs/tools.md**: Now includes tool descriptions and links to GitHub repos
2. **New TOOLS.md**: Lists supported tools, pending candidates, and tools confirmed without completion support
3. **Update docs**: Instructions for `mise upgrade` added to README and docs
4. **New task**: `mise run docs-status` to regenerate TOOLS.md

## Test plan
- [x] Run `mise run docs-tools` - generates enriched docs/tools.md
- [x] Run `mise run docs-status` - generates TOOLS.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)