### PR TITLE
fix(docs): trigger rebuild on CHANGELOG changes and include in site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,7 @@ on:
       - 'docs/**'
       - 'mkdocs.yml'
       - 'registry.toml'
+      - 'CHANGELOG.md'
   workflow_dispatch:
 
 permissions:
@@ -29,6 +30,9 @@ jobs:
 
       - name: Generate tools documentation
         run: uv run scripts/generate-tools-docs.py > docs/tools.md
+
+      - name: Copy CHANGELOG to docs
+        run: cp CHANGELOG.md docs/changelog.md
 
       - name: Build docs
         run: uvx --with mkdocs-material mkdocs build

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,3 +29,4 @@ nav:
     - Supported Tools: tools.md
     - How It Works: how-it-works.md
   - Development: development.md
+  - Changelog: changelog.md


### PR DESCRIPTION
## Summary
- Add CHANGELOG.md to docs workflow paths trigger
- Copy CHANGELOG to docs during build
- Add Changelog to site navigation

## Problem
When release-please creates a release, it only updates CHANGELOG.md and Cargo.toml. The docs workflow wasn't triggered because these files weren't in the paths filter.

## Solution
Now CHANGELOG.md changes trigger docs rebuild, and the changelog is included in the docs site.

## Test plan
- [x] Verify workflow triggers on CHANGELOG.md changes
- [ ] After merge, docs site should rebuild and include changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)