### PR TITLE
fix(scripts): handle missing mise in CI gracefully

### DIFF
--- a/scripts/generate-tools-docs.py
+++ b/scripts/generate-tools-docs.py
@@ -19,19 +19,20 @@ from pathlib import Path
 
 def get_mise_registry() -> dict[str, dict]:
     """Fetch tool metadata from mise's registry."""
-    result = subprocess.run(
-        ["mise", "registry", "--json"],
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode != 0:
-        return {}
-
     try:
+        result = subprocess.run(
+            ["mise", "registry", "--json"],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            return {}
+
         data = json.loads(result.stdout)
         # Convert list to dict keyed by short name
         return {item["short"]: item for item in data}
-    except (json.JSONDecodeError, KeyError):
+    except (FileNotFoundError, json.JSONDecodeError, KeyError):
+        # mise not installed or invalid output
         return {}
 
 


### PR DESCRIPTION
## Summary
Catch `FileNotFoundError` when mise isn't installed in CI.

## Problem
The docs workflow failed because `generate-tools-docs.py` calls `mise registry --json` but mise isn't installed in the CI runner.

## Solution
Wrap the subprocess call in try/except to catch `FileNotFoundError`. The script will generate docs without metadata instead of failing.

## Test plan
- [x] CI should pass now

🤖 Generated with [Claude Code](https://claude.com/claude-code)