### PR TITLE
fix(ci): remove auto-generation of tools docs from workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,9 +28,6 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@v7
 
-      - name: Generate tools documentation
-        run: uv run scripts/generate-tools-docs.py > docs/tools.md
-
       - name: Copy CHANGELOG to docs
         run: cp CHANGELOG.md docs/changelog.md
 


### PR DESCRIPTION
Tools documentation will be generated manually via `mise run docs-tools` and committed to the repo.