### PR TITLE
feat: add support for completion commands with specific env var

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -17,6 +17,7 @@ These tools are in mise's registry but not yet supported. They may have completi
 |------|-------------|--------|
 | [1password](https://github.com/1password/cli) | Password manager developed by AgileBits Inc | Needs testing |
 | aapt2 | Android Asset Packaging Tool (aapt) | Needs testing |
+| [acli](https://github.com/atlassian.com/acli) | Software to interact with Atlassian Cloud from ... | Needs testing |
 | [act](https://github.com/nektos/act) | Run your GitHub Actions locally | Needs testing |
 | [action-validator](https://github.com/mpalmer/action-validator) | Tool to validate GitHub Action and Workflow YAM... | Needs testing |
 | [actionlint](https://github.com/rhysd/actionlint) | :octocat: Static checker for GitHub Actions wor... | Needs testing |
@@ -52,6 +53,7 @@ These tools are in mise's registry but not yet supported. They may have completi
 | [ast-grep](https://github.com/ast-grep/ast-grep) | A CLI tool for code structural search, lint and... | Needs testing |
 | astro | CLI that makes it easy to create, test and depl... | Needs testing |
 | [atlas](https://github.com/ariga/atlas) | A modern tool for managing database schemas | Needs testing |
+| [atlas-community](https://github.com/ariga/atlas) | A modern tool for managing database schemas (Co... | Needs testing |
 | [atmos](https://github.com/cloudposse/atmos) | Workflow automation tool for DevOps. Keep confi... | Needs testing |
 | auto-doc | Github action that turns your reusable workflow... | Needs testing |
 | aws-amplify | The AWS Amplify CLI is a toolchain for simplify... | Needs testing |
@@ -63,10 +65,8 @@ These tools are in mise's registry but not yet supported. They may have completi
 | [aws-sso](https://github.com/synfinatic/aws-sso-cli) | A powerful tool for using AWS Identity Center f... | Needs testing |
 | [aws-vault](https://github.com/ByteNess/aws-vault) | A vault for securely storing and accessing AWS ... | Needs testing |
 | awscli-local | This package provides the awslocal command, whi... | Needs testing |
-| awsebcli | The AWS Elastic Beanstalk Command Line Interfac... | Needs testing |
-| awsls | A list command for AWS resources | Needs testing |
 
-*...and 832 more tools in mise registry*
+*...and 800 more tools in mise registry*
 
 ## Tools Without Completion Support
 
@@ -80,6 +80,7 @@ These tools have been tested and confirmed to NOT output shell completion script
 - **dust**: A more intuitive version of du in rust
 - **evans**: Evans: more expressive universal gRPC client
 - **eza**: A modern, maintained replacement for ls
+- **gcloud**: GCloud CLI (Google Cloud SDK)
 - **nomad**: Nomad is an easy-to-use, flexible, and performa...
 - **terraform**: Terraform enables you to safely and predictably...
 - **tokei**: Count your code, quickly

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -21,7 +21,6 @@ The following tools have shell completion support in mise-completions-sync.
 | flux |  | ✓ | ✓ | ✓ |
 | [flyctl](https://github.com/superfly/flyctl) | Command line tools for fly.io services | ✓ | ✓ | ✓ |
 | [fzf](https://github.com/junegunn/fzf) | :cherry_blossom: A command-line fuzzy finder | ✓ | ✓ | ✓ |
-| gcloud | GCloud CLI (Google Cloud SDK) | ✓ | ✓ |  |
 | [gh](https://github.com/cli/cli) | GitHub’s official command line tool | ✓ | ✓ | ✓ |
 | [gitu](https://github.com/altsem/gitu) | A TUI Git client inspired by Magit | ✓ | ✓ | ✓ |
 | [gitui](https://github.com/extrawurst/gitui) | Blazing 💥 fast terminal-ui for git written in rust | ✓ | ✓ | ✓ |
@@ -59,6 +58,7 @@ The following tools have shell completion support in mise-completions-sync.
 | [pnpm](https://github.com/pnpm/pnpm) | Fast, disk space efficient package manager | ✓ | ✓ |  |
 | podman | Podman: A tool for managing OCI containers and ... | ✓ | ✓ | ✓ |
 | poetry | Python packaging and dependency management made... | ✓ | ✓ | ✓ |
+| [prek](https://github.com/j178/prek) |  | ✓ | ✓ | ✓ |
 | [pulumi](https://github.com/pulumi/pulumi) | Pulumi - Infrastructure as Code in any programm... | ✓ | ✓ | ✓ |
 | [restic](https://github.com/restic/restic) | Fast, secure, efficient backup program | ✓ | ✓ | ✓ |
 | [rg](https://github.com/BurntSushi/ripgrep) | ripgrep recursively searches directories for a ... | ✓ | ✓ | ✓ |
@@ -77,7 +77,7 @@ The following tools have shell completion support in mise-completions-sync.
 | [ty](https://github.com/astral-sh/ty) | An extremely fast Python type checker and langu... | ✓ | ✓ | ✓ |
 | [uv](https://github.com/astral-sh/uv) | An extremely fast Python package installer and ... | ✓ | ✓ | ✓ |
 | [velero](https://github.com/vmware-tanzu/velero) | Backup and migrate Kubernetes applications and ... | ✓ | ✓ | ✓ |
-| vercel |  | ✓ | ✓ |  |
+| vercel | Build and deploy on the Vercel cloud | ✓ | ✓ |  |
 | [xh](https://github.com/ducaale/xh) | Friendly and fast tool for sending HTTP requests | ✓ | ✓ | ✓ |
 | [zellij](https://github.com/zellij-org/zellij) | A terminal workspace with batteries included | ✓ | ✓ | ✓ |
 | [zoxide](https://github.com/ajeetdsouza/zoxide) | A smarter cd command. Supports all major shells | ✓ | ✓ | ✓ |

--- a/registry.toml
+++ b/registry.toml
@@ -123,3 +123,9 @@ fzf = { zsh = "fzf --zsh", bash = "fzf --bash", fish = "fzf --fish" }
 
 # nix needs extra experimental features flag
 nix = { zsh = "nix --extra-experimental-features 'nix-command' completion zsh 2>/dev/null || true", bash = "nix --extra-experimental-features 'nix-command' completion bash 2>/dev/null || true", fish = "nix --extra-experimental-features 'nix-command' completion fish 2>/dev/null || true" }
+
+# Tools requiring environment variables (shell-specific)
+[tools.prek]
+zsh = { command = "prek --completions zsh", env = { COMPLETE = "zsh" } }
+bash = { command = "prek --completions bash", env = { COMPLETE = "bash" } }
+fish = { command = "prek --completions fish", env = { COMPLETE = "fish" } }

--- a/scripts/generate-registry.py
+++ b/scripts/generate-registry.py
@@ -14,10 +14,11 @@ Compares mise's registry against our registry.toml and suggests new tools
 to add based on known completion patterns.
 """
 
-import tomllib
-import httpx
 import sys
 from pathlib import Path
+
+import httpx
+import tomllib
 
 MISE_REGISTRY_URL = "https://raw.githubusercontent.com/jdx/mise/main/registry.toml"
 

--- a/scripts/validate-registry.py
+++ b/scripts/validate-registry.py
@@ -12,10 +12,12 @@ Tests each tool's completion command to verify it works. By default tests
 all entries; use --installed-only to skip tools not installed via mise.
 """
 
+import os
 import subprocess
 import sys
-import tomllib
 from pathlib import Path
+
+import tomllib
 
 
 def get_installed_tools() -> set[str]:
@@ -38,8 +40,12 @@ def get_installed_tools() -> set[str]:
         return set()
 
 
-def load_registry() -> dict[str, dict[str, str]]:
-    """Load registry.toml and expand patterns to get tool completions."""
+def load_registry() -> dict[str, dict[str, dict]]:
+    """Load registry.toml and expand patterns to get tool completions.
+
+    Returns a dict with tool names as keys and values containing shell-specific
+    completion info: {shell: {"command": str, "env": dict or None}}
+    """
     registry_path = Path(__file__).parent.parent / "registry.toml"
     with open(registry_path, "rb") as f:
         raw = tomllib.load(f)
@@ -53,28 +59,56 @@ def load_registry() -> dict[str, dict[str, str]]:
             # Pattern reference
             pattern = patterns.get(entry)
             if pattern is None:
-                print(f"Warning: unknown pattern '{entry}' for tool '{tool_name}'", file=sys.stderr)
+                print(
+                    f"Warning: unknown pattern '{entry}' for tool '{tool_name}'",
+                    file=sys.stderr,
+                )
                 continue
             # Expand {} placeholder with tool name
             expanded[tool_name] = {
-                shell: cmd.replace("{}", tool_name)
+                shell: {"command": cmd.replace("{}", tool_name), "env": None}
                 for shell, cmd in pattern.items()
             }
         else:
-            # Explicit commands
-            expanded[tool_name] = entry
+            # Explicit commands - handle both string and object formats
+            expanded[tool_name] = {}
+            for shell, value in entry.items():
+                if isinstance(value, str):
+                    # Simple string format
+                    expanded[tool_name][shell] = {"command": value, "env": None}
+                elif isinstance(value, dict):
+                    # Object format with command and env
+                    expanded[tool_name][shell] = {
+                        "command": value.get("command", ""),
+                        "env": value.get("env"),
+                    }
+                else:
+                    print(
+                        f"Warning: invalid format for {tool_name}.{shell}",
+                        file=sys.stderr,
+                    )
 
     return expanded
 
 
-def test_completion(tool: str, shell: str, command: str) -> tuple[bool, str]:
+def test_completion(
+    tool: str, shell: str, command: str, env_vars: dict[str, str] | None = None
+) -> tuple[bool, str]:
     """Test a completion command. Returns (success, error_message)."""
     wrapped = f"mise x {tool} -- {command}"
+
+    # Build environment with optional vars
+    env = None
+    if env_vars:
+        env = os.environ.copy()
+        env.update(env_vars)
+
     result = subprocess.run(
         ["sh", "-c", wrapped],
         capture_output=True,
         text=True,
         timeout=30,
+        env=env,
     )
 
     if result.returncode == 0 and result.stdout.strip():
@@ -91,7 +125,6 @@ def main():
     installed = get_installed_tools() if installed_only else set()
 
     results: dict[str, dict[str, tuple[bool, str]]] = {}
-    shells = ["zsh", "bash", "fish"]
 
     tools = sorted(registry.keys())
     total = len(tools)
@@ -108,13 +141,12 @@ def main():
         print(f"[{i}/{total}] {tool}...", end=" ", flush=True)
         tool_ok = True
 
-        for shell in shells:
-            if shell not in completions:
-                continue
+        for shell, completion_data in completions.items():
+            command = completion_data["command"]
+            env_vars = completion_data.get("env")
 
-            command = completions[shell]
             try:
-                ok, err = test_completion(tool, shell, command)
+                ok, err = test_completion(tool, shell, command, env_vars)
                 results[tool][shell] = (ok, err)
                 if not ok:
                     tool_ok = False
@@ -144,7 +176,9 @@ def main():
             else:
                 if tool not in failures:
                     failures[tool] = []
-                failures[tool].append((shell, registry[tool][shell], err))
+                # Get the original command for display
+                cmd = registry[tool][shell]["command"]
+                failures[tool].append((shell, cmd, err))
 
     print(f"\nPassed: {successes}/{total_tests}")
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -10,12 +10,20 @@ use crate::sync::Error;
 const EMBEDDED_REGISTRY: &str = include_str!("../registry.toml");
 const CURRENT_SCHEMA_VERSION: u32 = 1;
 
+/// Raw registry format for deserialization (supports both string and object formats)
+#[derive(Debug, Deserialize)]
+struct RawToolCompletions {
+    zsh: Option<ShellCommand>,
+    bash: Option<ShellCommand>,
+    fish: Option<ShellCommand>,
+}
+
 /// Parsed registry format with patterns and tools sections
 #[derive(Debug, Deserialize)]
 struct RawRegistry {
     schema_version: Option<u32>,
     #[serde(default)]
-    patterns: HashMap<String, ToolCompletions>,
+    patterns: HashMap<String, RawToolCompletions>,
     #[serde(default)]
     tools: HashMap<String, ToolEntry>,
 }
@@ -25,7 +33,34 @@ struct RawRegistry {
 #[serde(untagged)]
 enum ToolEntry {
     Pattern(String),
-    Explicit(ToolCompletions),
+    Explicit(RawToolCompletions),
+}
+
+/// Shell command with optional environment variables
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+enum ShellCommand {
+    Simple(String),
+    WithEnv {
+        command: String,
+        env: Option<std::collections::HashMap<String, String>>,
+    },
+}
+
+impl ShellCommand {
+    fn command(&self) -> &str {
+        match self {
+            ShellCommand::Simple(cmd) => cmd,
+            ShellCommand::WithEnv { command, .. } => command,
+        }
+    }
+
+    fn env(&self) -> Option<&std::collections::HashMap<String, String>> {
+        match self {
+            ShellCommand::Simple(_) => None,
+            ShellCommand::WithEnv { env, .. } => env.as_ref(),
+        }
+    }
 }
 
 /// Expanded registry with all patterns resolved
@@ -39,6 +74,9 @@ pub struct ToolCompletions {
     pub zsh: Option<String>,
     pub bash: Option<String>,
     pub fish: Option<String>,
+    pub zsh_env: Option<std::collections::HashMap<String, String>>,
+    pub bash_env: Option<std::collections::HashMap<String, String>>,
+    pub fish_env: Option<std::collections::HashMap<String, String>>,
 }
 
 impl ToolCompletions {
@@ -51,12 +89,42 @@ impl ToolCompletions {
         }
     }
 
+    pub fn get_env(&self, shell: &str) -> Option<&std::collections::HashMap<String, String>> {
+        match shell {
+            "zsh" => self.zsh_env.as_ref(),
+            "bash" => self.bash_env.as_ref(),
+            "fish" => self.fish_env.as_ref(),
+            _ => None,
+        }
+    }
+
     /// Expand pattern placeholders with tool name
     fn expand(&self, tool_name: &str) -> Self {
         Self {
             zsh: self.zsh.as_ref().map(|s| s.replace("{}", tool_name)),
             bash: self.bash.as_ref().map(|s| s.replace("{}", tool_name)),
             fish: self.fish.as_ref().map(|s| s.replace("{}", tool_name)),
+            zsh_env: self.zsh_env.clone(),
+            bash_env: self.bash_env.clone(),
+            fish_env: self.fish_env.clone(),
+        }
+    }
+}
+
+impl ToolCompletions {
+    /// Create from raw shell commands (for deserialization)
+    fn from_raw(
+        zsh: Option<ShellCommand>,
+        bash: Option<ShellCommand>,
+        fish: Option<ShellCommand>,
+    ) -> Self {
+        Self {
+            zsh: zsh.as_ref().map(|s| s.command().to_string()),
+            bash: bash.as_ref().map(|s| s.command().to_string()),
+            fish: fish.as_ref().map(|s| s.command().to_string()),
+            zsh_env: zsh.and_then(|s| s.env().cloned()),
+            bash_env: bash.and_then(|s| s.env().cloned()),
+            fish_env: fish.and_then(|s| s.env().cloned()),
         }
     }
 }
@@ -114,12 +182,79 @@ pub fn load_registry() -> Result<Registry, Error> {
                 let pattern = raw.patterns.get(&pattern_name).ok_or_else(|| {
                     Error::UnknownPattern(tool_name.clone(), pattern_name.clone())
                 })?;
-                pattern.expand(&tool_name)
+                ToolCompletions::from_raw(
+                    pattern.zsh.clone(),
+                    pattern.bash.clone(),
+                    pattern.fish.clone(),
+                )
+                .expand(&tool_name)
             }
-            ToolEntry::Explicit(completions) => completions,
+            ToolEntry::Explicit(raw_completions) => ToolCompletions::from_raw(
+                raw_completions.zsh,
+                raw_completions.bash,
+                raw_completions.fish,
+            ),
         };
         tools.insert(tool_name, completions);
     }
 
     Ok(Registry { tools })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_registry_with_env_vars() {
+        let registry = load_registry().expect("Failed to load registry");
+
+        // Check that prek has env vars
+        if let Some(prek_completions) = registry.tools.get("prek") {
+            // Test shell-specific env vars
+            assert!(
+                prek_completions.fish_env.is_some(),
+                "prek should have fish env vars"
+            );
+            let fish_env = prek_completions.fish_env.as_ref().unwrap();
+            assert_eq!(fish_env.get("COMPLETE"), Some(&"fish".to_string()));
+        } else {
+            panic!("prek not found in registry");
+        }
+    }
+
+    #[test]
+    fn test_registry_without_env_vars() {
+        let registry = load_registry().expect("Failed to load registry");
+
+        // Check that kubectl doesn't have env vars (uses pattern)
+        if let Some(kubectl_completions) = registry.tools.get("kubectl") {
+            assert!(
+                kubectl_completions.zsh_env.is_none(),
+                "kubectl should not have zsh env vars"
+            );
+            assert!(
+                kubectl_completions.bash_env.is_none(),
+                "kubectl should not have bash env vars"
+            );
+            assert!(
+                kubectl_completions.fish_env.is_none(),
+                "kubectl should not have fish env vars"
+            );
+        } else {
+            panic!("kubectl not found in registry");
+        }
+    }
+
+    #[test]
+    fn test_shell_specific_env_vars() {
+        // Test that different shells can have different env vars
+        let registry = load_registry().expect("Failed to load registry");
+
+        if let Some(prek_completions) = registry.tools.get("prek") {
+            // Fish should have COMPLETE=fish
+            assert!(prek_completions.fish_env.is_some());
+            // Zsh and bash might have different or no env vars
+        }
+    }
 }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -93,14 +93,24 @@ fn generate_completion(
     command: &str,
     shell: &str,
     output_dir: &PathBuf,
+    env_vars: Option<&std::collections::HashMap<String, String>>,
 ) -> Result<(), Error> {
     // Create output directory if needed
     std::fs::create_dir_all(output_dir).map_err(|e| Error::CreateDir(output_dir.clone(), e))?;
 
     // Run the completion command wrapped with mise to ensure the tool is available
     let wrapped_command = format!("mise x {tool} -- {command}");
-    let output = Command::new("sh")
-        .args(["-c", &wrapped_command])
+    let mut cmd = Command::new("sh");
+    cmd.args(["-c", &wrapped_command]);
+
+    // Add shell-specific environment variables if provided
+    if let Some(env) = env_vars {
+        for (key, value) in env {
+            cmd.env(key, value);
+        }
+    }
+
+    let output = cmd
         .output()
         .map_err(|e| Error::Generate(tool.to_string(), e.to_string()))?;
 
@@ -154,7 +164,8 @@ pub fn sync_completions(shells: &[String], specific_tools: &[String]) -> Result<
         for tool in &tools_in_registry {
             if let Some(completions) = registry.tools.get(*tool) {
                 if let Some(cmd) = completions.get(shell) {
-                    if let Err(e) = generate_completion(tool, cmd, shell, &output_dir) {
+                    let env = completions.get_env(shell);
+                    if let Err(e) = generate_completion(tool, cmd, shell, &output_dir, env) {
                         eprintln!("  {tool}: {e}");
                     }
                 }


### PR DESCRIPTION
- Update registry.toml with prek completion commands and environment variables
- Refactor registry parsing to support shell-specific environment variables
- Add tests for registry with and without environment variables

closes #36 