### PR TITLE
fix: remove unused json import

### DIFF
--- a/scripts/generate-registry.py
+++ b/scripts/generate-registry.py
@@ -14,7 +14,6 @@ Fetches tools from https://mise-versions.jdx.dev/api/tools and compares
 against our registry.toml to suggest new tools to add.
 """
 
-import json
 import tomllib
 import httpx
 from pathlib import Path


### PR DESCRIPTION
## Summary
- Remove unused `import json` introduced in #42. The script uses `response.json()` (httpx method), not `json.loads()`.

## Test plan
- [x] Verified script runs successfully without the import

🤖 Generated with [Claude Code](https://claude.com/claude-code)