### PR TITLE
feat: add prek completion support

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -116,6 +116,8 @@ cargo = { zsh = "rustup completions zsh cargo", bash = "rustup completions bash 
 # pipx uses argcomplete
 pipx = { zsh = "register-python-argcomplete pipx", bash = "register-python-argcomplete pipx" }
 
+prek = { zsh = "prek util generate-shell-completion zsh", bash = "prek util generate-shell-completion bash", fish = "prek util generate-shell-completion fish" }
+
 # Unique command patterns
 just = { zsh = "just --completions zsh", bash = "just --completions bash", fish = "just --completions fish" }
 task = { zsh = "task --completion zsh", bash = "task --completion bash", fish = "task --completion fish" }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -123,3 +123,29 @@ pub fn load_registry() -> Result<Registry, Error> {
 
     Ok(Registry { tools })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_prek_in_registry() {
+        let registry = load_registry().expect("Failed to load registry");
+        let prek = registry
+            .tools
+            .get("prek")
+            .expect("prek should be in registry");
+        assert_eq!(
+            prek.zsh.as_deref(),
+            Some("prek util generate-shell-completion zsh")
+        );
+        assert_eq!(
+            prek.bash.as_deref(),
+            Some("prek util generate-shell-completion bash")
+        );
+        assert_eq!(
+            prek.fish.as_deref(),
+            Some("prek util generate-shell-completion fish")
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Adds prek to the completion registry using `prek util generate-shell-completion <shell>`
- Adds a test to verify prek is correctly loaded from the registry

Closes #36 — supersedes #43

## Investigation

Tested all three potential completion approaches for prek:

| Approach | Result |
|----------|--------|
| `prek --completions <shell>` | Does not exist (errors) |
| `COMPLETE=<shell> prek` (env var) | Produces dynamic stubs only (~35 lines) |
| `prek util generate-shell-completion <shell>` | Full static completions (664–2100 lines) |

The hidden subcommand produces proper static completions and fits the existing registry format with no code changes needed.

## Test plan

- [x] `cargo test` passes (4 tests including new `test_prek_in_registry`)
- [x] `uv run scripts/validate-registry.py --installed-only` validates prek successfully
- [x] Verified completion output is real shell completion code (1057 lines for zsh)

🤖 Generated with [Claude Code](https://claude.com/claude-code)