### PR TITLE
ci: validate PR titles as conventional commits

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,32 @@
+name: PR Title
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            chore
+            docs
+            ci
+            refactor
+            perf
+            style
+            build
+            test
+          requireScope: false
+          subjectPattern: ^[a-z].+[^.]$
+          subjectPatternError: |
+            The subject "{subject}" must start with a lowercase letter and not end with a period.


### PR DESCRIPTION
## Summary

Prevents PRs from being silently dropped by release-please.

PR #63 merged with subject `Adopt vacant 0.3.0 release pipeline: crates.io + Homebrew tap`. release-please failed to parse it (`unexpected token ' ' at 1:6, valid tokens [(, !, :]`) and skipped the only commit between v0.5.1 and HEAD, so no release PR was opened. Other commits in the same release window mask this — it only surfaces when a non-conventional PR is the sole change since the previous release.

Adds `amannn/action-semantic-pull-request` to enforce a conventional-commit-shaped PR title before merge. Allowed types match the `changelog-sections` in `.release-please-config.json` so anything that lints clean also produces a valid changelog entry.

## Why this works for our merge settings

This repo squash-merges with `squash_merge_commit_title: COMMIT_OR_PR_TITLE`. Multi-commit PRs (like #63) take the squash subject from the PR title; single-commit PRs take it from the commit subject. Validating the PR title covers the multi-commit case directly. Single-commit PRs need a conventional commit, which our pre-commit hooks already encourage; not adding a separate guard for that.

## Notes

Same exposure exists in `alltuner/vacant` and `alltuner/vaultuner`. Filing a tracking issue at vacant per request.

## Test plan

- [ ] CI passes (Documentation, CI workflows still run)
- [ ] After merge, opening a PR with non-conventional title gets a failed status check
- [ ] Opening a PR with `feat: ...` title passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)