### PR TITLE
docs: standardize README to alltuner brand structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 <p align="center">
   <a href="https://alltuner.github.io/mise-completions-sync/">Docs</a> &middot;
-  <a href="https://github.com/sponsors/alltuner">Sponsor</a>
+  <a href="https://alltuner.com/sponsor">Sponsor</a>
 </p>
 
 <p align="center">
@@ -103,15 +103,7 @@ Full docs at [alltuner.github.io/mise-completions-sync](https://alltuner.github.
 
 mise-completions-sync is an open source project built by [David Poblador i Garcia](https://davidpoblador.com/) through [All Tuner Labs](https://www.alltuner.com/).
 
-If this project saved you a few `compinit` headaches, consider supporting its development.
-
-❤️ **Sponsor development**
-https://github.com/sponsors/alltuner
-
-☕ **One-time support**
-https://buymeacoffee.com/alltuner
-
-Your support helps fund the continued development of mise-completions-sync and other open source developer tools such as [Factory Floor](https://github.com/alltuner/factoryfloor).
+If this project was useful to you, [consider supporting its development](https://alltuner.com/sponsor).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,46 +1,52 @@
-# mise-completions-sync
+<h1 align="center">mise-completions-sync</h1>
 
-Automatically sync shell completions for tools managed by [mise](https://mise.jdx.dev/).
+<p align="center">
+  <strong>Sync shell completions for tools managed by mise.</strong><br>
+  One command keeps Bash, Zsh, and Fish completions current as <a href="https://mise.jdx.dev/">mise</a> installs and removes tools.
+</p>
 
-## Installation
+<p align="center">
+  <a href="https://alltuner.github.io/mise-completions-sync/">Docs</a> &middot;
+  <a href="https://github.com/sponsors/alltuner">Sponsor</a>
+</p>
 
-**Homebrew:**
+<p align="center">
+  <img src="https://img.shields.io/crates/v/mise-completions-sync?color=5B2333" alt="crates.io">
+  <img src="https://img.shields.io/github/license/alltuner/mise-completions-sync?color=5B2333" alt="License">
+  <img src="https://img.shields.io/github/stars/alltuner/mise-completions-sync?color=5B2333" alt="Stars">
+</p>
+
+---
+
+## Get Started
+
+Install via Homebrew, Cargo, mise, or grab a [prebuilt binary](https://github.com/alltuner/mise-completions-sync/releases):
+
 ```bash
 brew install alltuner/tap/mise-completions-sync
 ```
 
-**Cargo:**
 ```bash
 cargo install mise-completions-sync
 ```
 
-**mise:**
 ```bash
 mise use -g github:alltuner/mise-completions-sync
 ```
 
-Or download a prebuilt binary from [releases](https://github.com/alltuner/mise-completions-sync/releases).
+Then add the completions directory to your shell config:
 
-## Shell Setup
+| Shell | Where to add | Snippet |
+|---|---|---|
+| Zsh  | `~/.zshrc` (before `compinit`) | `fpath=(${XDG_DATA_HOME:-$HOME/.local/share}/mise-completions/zsh $fpath)` |
+| Bash | `~/.bashrc` | `for f in ${XDG_DATA_HOME:-$HOME/.local/share}/mise-completions/bash/*; do [[ -f "$f" ]] && source "$f"; done` |
+| Fish | `~/.config/fish/config.fish` | `set -gx fish_complete_path $fish_complete_path ~/.local/share/mise-completions/fish` |
 
-Add the completions directory to your shell config.
+---
 
-**ZSH** - add to `~/.zshrc` before `compinit`:
-```zsh
-fpath=(${XDG_DATA_HOME:-$HOME/.local/share}/mise-completions/zsh $fpath)
-```
+## What is mise-completions-sync?
 
-**Bash** - add to `~/.bashrc`:
-```bash
-for f in ${XDG_DATA_HOME:-$HOME/.local/share}/mise-completions/bash/*; do
-  [[ -f "$f" ]] && source "$f"
-done
-```
-
-**Fish** - add to `~/.config/fish/config.fish`:
-```fish
-set -gx fish_complete_path $fish_complete_path ~/.local/share/mise-completions/fish
-```
+mise installs language and tool versions per project, but it doesn't touch your shell completion files. As versions change, completions get stale or missing. `mise-completions-sync` walks your installed mise tools, generates the right completion file for each one (Bash, Zsh, Fish), and writes them under `${XDG_DATA_HOME:-$HOME/.local/share}/mise-completions/<shell>/`. Run it once after installing tools, or wire it into a mise post-install hook.
 
 ## Usage
 
@@ -48,7 +54,7 @@ set -gx fish_complete_path $fish_complete_path ~/.local/share/mise-completions/f
 # Sync completions for all installed tools
 mise-completions-sync
 
-# Sync only for specific shell
+# Sync only for a specific shell
 mise-completions-sync --shell zsh
 
 # Sync specific tools
@@ -61,31 +67,9 @@ mise-completions-sync list
 mise-completions-sync clean
 ```
 
-## Updating
+### Automatic sync
 
-**Homebrew:**
-```bash
-brew upgrade mise-completions-sync
-```
-
-**Cargo:**
-```bash
-cargo install --force mise-completions-sync
-```
-
-**mise:**
-```bash
-mise upgrade github:alltuner/mise-completions-sync
-```
-
-Or pin a specific version with mise:
-```bash
-mise use -g github:alltuner/mise-completions-sync@0.5.1
-```
-
-## Automatic Sync
-
-Set up a mise hook to sync completions when tools are installed:
+Wire it into a mise post-install hook so new tool installs get completions automatically:
 
 ```bash
 mkdir -p ~/.config/mise && cat >> ~/.config/mise/config.toml << 'EOF'
@@ -95,14 +79,47 @@ postinstall = "mise-completions-sync"
 EOF
 ```
 
+## Updating
+
+```bash
+# Homebrew
+brew upgrade mise-completions-sync
+
+# Cargo
+cargo install --force mise-completions-sync
+
+# mise
+mise upgrade github:alltuner/mise-completions-sync
+
+# Pin a specific version with mise
+mise use -g github:alltuner/mise-completions-sync@0.5.1
+```
+
 ## Documentation
 
-See the [full documentation](https://alltuner.github.io/mise-completions-sync/) for supported tools and more details.
+Full docs at [alltuner.github.io/mise-completions-sync](https://alltuner.github.io/mise-completions-sync/) — supported tools, completion details, and troubleshooting.
+
+## Support the project
+
+mise-completions-sync is an open source project built by [David Poblador i Garcia](https://davidpoblador.com/) through [All Tuner Labs](https://www.alltuner.com/).
+
+If this project saved you a few `compinit` headaches, consider supporting its development.
+
+❤️ **Sponsor development**
+https://github.com/sponsors/alltuner
+
+☕ **One-time support**
+https://buymeacoffee.com/alltuner
+
+Your support helps fund the continued development of mise-completions-sync and other open source developer tools such as [Factory Floor](https://github.com/alltuner/factoryfloor).
 
 ## License
 
-MIT
+[MIT](LICENSE)
 
 ---
 
-Built at [All Tuner Labs](https://alltuner.com) by [David Poblador i Garcia](https://davidpoblador.com)
+<p align="center">
+  Built by <a href="https://davidpoblador.com">David Poblador i Garcia</a> with the support of <a href="https://alltuner.com">All Tuner Labs</a>.<br>
+  Made with ❤️ in Poblenou, Barcelona.
+</p>

--- a/README.md
+++ b/README.md
@@ -99,15 +99,15 @@ mise use -g github:alltuner/mise-completions-sync@0.5.1
 
 Full docs at [alltuner.github.io/mise-completions-sync](https://alltuner.github.io/mise-completions-sync/) — supported tools, completion details, and troubleshooting.
 
+## License
+
+[MIT](LICENSE)
+
 ## Support the project
 
 mise-completions-sync is an open source project built by [David Poblador i Garcia](https://davidpoblador.com/) through [All Tuner Labs](https://www.alltuner.com/).
 
 If this project was useful to you, [consider supporting its development](https://alltuner.com/sponsor).
-
-## License
-
-[MIT](LICENSE)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-<h1 align="center">mise-completions-sync</h1>
+<p align="center">
+  <img src="https://brand.alltuner.com/logos/mise-completions-sync/horizontal.png" alt="mise-completions-sync" width="500">
+</p>
 
 <p align="center">
   <strong>Sync shell completions for tools managed by mise.</strong><br>


### PR DESCRIPTION
## Summary

- Adds the centered hero (title, tagline, link row, Wine-coloured shields).
- Adds the canonical "Support the project" block.
- Reformats shell-setup snippets as a table — fewer scrolls, easier to compare across shells.
- Adds a one-paragraph pitch under "What is mise-completions-sync?".
- Replaces the single-line footer with the canonical Poblenou signature.

Follows the canonical README template at `alltuner/brand:readme-template`.

## Test plan

- [ ] Render on github.com and verify the centered blocks and tables.
- [ ] Confirm the install / shell-setup snippets still copy-paste cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)