### PR TITLE
fix: rename installed binary to misecompsync (closes #79)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Create archive
         run: |
           cd target/${{ matrix.target }}/release
-          tar -czvf ../../../mise-completions-sync-${{ matrix.target }}.tar.gz mise-completions-sync
+          tar -czvf ../../../mise-completions-sync-${{ matrix.target }}.tar.gz misecompsync
 
       - name: Upload to release
         uses: softprops/action-gh-release@v3
@@ -128,11 +128,11 @@ jobs:
             end
 
             def install
-              bin.install "mise-completions-sync"
+              bin.install "misecompsync"
             end
 
             test do
-              system bin/"mise-completions-sync", "--help"
+              system bin/"misecompsync", "--help"
             end
           end
           RUBY

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ thiserror = "2"
 serde_json = "1"
 
 [[bin]]
-name = "mise-completions-sync"
+name = "misecompsync"
 path = "src/main.rs"
 
 [profile.release]

--- a/README.md
+++ b/README.md
@@ -48,25 +48,27 @@ Then add the completions directory to your shell config:
 
 ## What is mise-completions-sync?
 
-mise installs language and tool versions per project, but it doesn't touch your shell completion files. As versions change, completions get stale or missing. `mise-completions-sync` walks your installed mise tools, generates the right completion file for each one (Bash, Zsh, Fish), and writes them under `${XDG_DATA_HOME:-$HOME/.local/share}/mise-completions/<shell>/`. Run it once after installing tools, or wire it into a mise post-install hook.
+mise installs language and tool versions per project, but it doesn't touch your shell completion files. As versions change, completions get stale or missing. mise-completions-sync walks your installed mise tools, generates the right completion file for each one (Bash, Zsh, Fish), and writes them under `${XDG_DATA_HOME:-$HOME/.local/share}/mise-completions/<shell>/`. Run it once after installing tools, or wire it into a mise post-install hook.
+
+The package is `mise-completions-sync`; the binary it installs is `misecompsync`. (mise reserves `mise-*` binary names for itself, so the shim can't forward to a binary that starts with `mise-`.)
 
 ## Usage
 
 ```bash
 # Sync completions for all installed tools
-mise-completions-sync
+misecompsync
 
 # Sync only for a specific shell
-mise-completions-sync --shell zsh
+misecompsync --shell zsh
 
 # Sync specific tools
-mise-completions-sync kubectl helm
+misecompsync kubectl helm
 
 # List supported tools
-mise-completions-sync list
+misecompsync list
 
 # Clean up completions for uninstalled tools
-mise-completions-sync clean
+misecompsync clean
 ```
 
 ### Automatic sync
@@ -77,7 +79,7 @@ Wire it into a mise post-install hook so new tool installs get completions autom
 mkdir -p ~/.config/mise && cat >> ~/.config/mise/config.toml << 'EOF'
 
 [hooks]
-postinstall = "mise-completions-sync"
+postinstall = "misecompsync"
 EOF
 ```
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ cargo install mise-completions-sync
 mise use -g github:alltuner/mise-completions-sync
 ```
 
+The installed binary is named `misecompsync` (mise reserves `mise-*` names for itself, so the shim can't forward to a binary that starts with `mise-`).
+
 Then add the completions directory to your shell config:
 
 | Shell | Where to add | Snippet |
@@ -49,8 +51,6 @@ Then add the completions directory to your shell config:
 ## What is mise-completions-sync?
 
 mise installs language and tool versions per project, but it doesn't touch your shell completion files. As versions change, completions get stale or missing. mise-completions-sync walks your installed mise tools, generates the right completion file for each one (Bash, Zsh, Fish), and writes them under `${XDG_DATA_HOME:-$HOME/.local/share}/mise-completions/<shell>/`. Run it once after installing tools, or wire it into a mise post-install hook.
-
-The package is `mise-completions-sync`; the binary it installs is `misecompsync`. (mise reserves `mise-*` binary names for itself, so the shim can't forward to a binary that starts with `mise-`.)
 
 ## Usage
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -1,6 +1,6 @@
 # How It Works
 
-`mise-completions-sync` follows a simple process to generate shell completions:
+mise-completions-sync follows a simple process to generate shell completions:
 
 1. **Discover installed tools** - Gets list of installed tools via `mise ls --installed --json`
 2. **Look up registry entries** - Each tool is matched against the built-in registry

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,9 +8,11 @@ When mise installs a tool like `kubectl` or `gh`, you don't automatically get sh
 
 ## The Solution
 
-mise-completions-sync automatically generates completions for all your mise-installed tools. The package is named `mise-completions-sync`; the binary it installs is `misecompsync` (mise reserves `mise-*` binary names for itself, so the shim can't forward to a binary that starts with `mise-`).
+mise-completions-sync automatically generates completions for all your mise-installed tools.
 
 ## Installation
+
+The package is named `mise-completions-sync`; the binary it installs is `misecompsync` (mise reserves `mise-*` names for itself, so the shim can't forward to a binary that starts with `mise-`).
 
 ### Homebrew
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ When mise installs a tool like `kubectl` or `gh`, you don't automatically get sh
 
 ## The Solution
 
-`mise-completions-sync` automatically generates completions for all your mise-installed tools.
+mise-completions-sync automatically generates completions for all your mise-installed tools. The package is named `mise-completions-sync`; the binary it installs is `misecompsync` (mise reserves `mise-*` binary names for itself, so the shim can't forward to a binary that starts with `mise-`).
 
 ## Installation
 
@@ -98,7 +98,7 @@ Set up a mise hook to automatically sync completions when tools are installed:
 mkdir -p ~/.config/mise && cat >> ~/.config/mise/config.toml << 'EOF'
 
 [hooks]
-postinstall = "mise-completions-sync"
+postinstall = "misecompsync"
 EOF
 ```
 
@@ -107,29 +107,29 @@ EOF
 After setup, run the initial sync:
 
 ```bash
-mise-completions-sync
+misecompsync
 ```
 
 ## Usage
 
 ```bash
 # Sync completions for all installed tools (all shells)
-mise-completions-sync
+misecompsync
 
 # Sync only for specific shell
-mise-completions-sync --shell zsh
+misecompsync --shell zsh
 
 # Sync specific tool(s)
-mise-completions-sync kubectl helm
+misecompsync kubectl helm
 
 # List tools with completion support
-mise-completions-sync list
+misecompsync list
 
 # Show completion directory for a shell
-mise-completions-sync dir zsh
+misecompsync dir zsh
 
 # Clean up completions for uninstalled tools
-mise-completions-sync clean
+misecompsync clean
 ```
 
 ## License

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ mod sync;
 use clap::{Parser, Subcommand};
 
 #[derive(Parser)]
-#[command(name = "mise-completions-sync")]
+#[command(name = "misecompsync")]
 #[command(about = "Sync shell completions for tools managed by mise")]
 #[command(version)]
 struct Cli {


### PR DESCRIPTION
## Summary

- Rename the installed binary from `mise-completions-sync` to `misecompsync` (package, crate, repo, release tarballs, Homebrew formula filename all keep the `mise-completions-sync` name).
- Update release workflow tar packaging and brew formula `bin.install` / `test` to reference the new binary.
- Update CLI invocations in README and docs to `misecompsync`; surface a one-line note next to the install steps explaining why.

## Why

`~/.local/share/mise/shims/mise-completions-sync` is a symlink to the mise binary. mise decides whether it's running as a shim by checking `argv[0]` via `is_mise_binary()` (`mise/src/env.rs`):

```rust
pub fn is_mise_binary(bin_name: &str) -> bool {
    bin_name == "mise" || bin_name.starts_with("mise.") || bin_name.starts_with("mise-")
}
```

Any name starting with `mise-` is treated as mise itself, so the shim never forwarded to our binary — it fell straight through to mise's own dispatcher, producing the broken help output in #79 (mise's top-level help with our argv[0] in the usage line). `misecompsync` has no hyphen after `mise`, so it bypasses the check.

## Test plan

- [x] `cargo build --release` succeeds; `target/release/misecompsync --help` shows our help text and `Usage: misecompsync …`
- [x] `cargo test --release` (4 tests pass)
- [x] `cargo clippy --release -- -D warnings` clean
- [x] Confirmed `misecompsync` does not match `is_mise_binary`'s `mise`/`mise.*`/`mise-*` patterns
- [ ] After merge + release, install via mise (`mise use -g github:alltuner/mise-completions-sync`) and verify `~/.local/share/mise/shims/misecompsync -h` prints our help

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)