### PR TITLE
feat: add --new-only flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ If you want to only generate completions for newly installed or updated tools, y
 
 ```toml
 [hooks]
-postinstall = "mise-completions-sync --new-only"
+postinstall = "misecompsync --new-only"
 ```
 
 ## Updating

--- a/README.md
+++ b/README.md
@@ -112,6 +112,13 @@ export MISE_COMPLETIONS_SYNC_FISH_DIR="$XDG_DATA_HOME/fish/vendor_completions.d"
 
 Note: Target directories will be created if they don't already exist. Don't forget to update your shell setup above.
 
+If you want to only generate completions for newly installed or updated tools, you can add the flag `--new-only`:
+
+```toml
+[hooks]
+postinstall = "mise-completions-sync --new-only"
+```
+
 ## Updating
 
 ```bash
@@ -127,6 +134,7 @@ mise upgrade github:alltuner/mise-completions-sync
 # Pin a specific version with mise
 mise use -g github:alltuner/mise-completions-sync@0.5.1
 ```
+
 ## Documentation
 
 Full docs at [alltuner.github.io/mise-completions-sync](https://alltuner.github.io/mise-completions-sync/) — supported tools, completion details, and troubleshooting.

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -39,7 +39,7 @@ You can override the default output directory using the `MISE_COMPLETIONS_SYNC_H
 ```shell
 export MISE_COMPLETIONS_SYNC_HOME="$XDG_DATA_HOME/custom-vendor-completions"
 
-mise-completions-sync kubectl
+misecompsync kubectl
 #  [fish] -> ~/.local/share/custom-vendor-completions/fish/kubectl.fish
 #  [zsh]  -> ~/.local/share/custom-vendor-completions/zsh/_kubectl
 #  [bash] -> ~/.local/share/custom-vendor-completions/bash/kubectl
@@ -50,7 +50,7 @@ Or you can override output directories for one (or more) shells (e.g., `MISE_COM
 ```shell
 export MISE_COMPLETIONS_SYNC_FISH_DIR="$XDG_CONFIG_HOME/fish/completions"
 
-mise-completions-sync kubectl
+misecompsync kubectl
 #  [fish] -> ~/.config/fish/completions/kubectl.fish
 #  [zsh]  -> ~/.local/share/mise-completions/zsh/_kubectl
 #  [bash] -> ~/.local/share/mise-completions/bash/kubectl
@@ -62,7 +62,7 @@ Or a shell dir with base dir default (shell takes precedence):
 export MISE_COMPLETIONS_SYNC_HOME="$XDG_DATA_HOME/custom-vendor-completions"
 export MISE_COMPLETIONS_SYNC_ZSH_DIR="$XDG_DATA_HOME/zsh/site-functions"
 
-mise-completions-sync kubectl
+misecompsync kubectl
 #  [fish] -> ~/.local/share/custom-vendor-completions/fish/kubectl.fish
 #  [zsh]  -> ~/.local/share/zsh/site-functions/_kubectl
 #  [bash] -> ~/.local/share/custom-vendor-completions/bash/kubectl

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ struct Cli {
     tools: Vec<String>,
 
     /// Only sync completions for newly installed/updated tools (reads MISE_INSTALLED_TOOLS env var)
-    #[arg(long)]
+    #[arg(long, conflicts_with = "tools")]
     new_only: bool,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,10 @@ struct Cli {
     /// Specific tool(s) to sync (default: all installed)
     #[arg(value_name = "TOOL")]
     tools: Vec<String>,
+
+    /// Only sync completions for newly installed/updated tools (reads MISE_INSTALLED_TOOLS env var)
+    #[arg(long)]
+    new_only: bool,
 }
 
 #[derive(Subcommand)]
@@ -80,7 +84,7 @@ fn run() -> Result<(), sync::Error> {
             let shells = cli
                 .shell
                 .unwrap_or_else(|| vec!["zsh".to_string(), "bash".to_string(), "fish".to_string()]);
-            sync::sync_completions(&dirs, &shells, &cli.tools)
+            sync::sync_completions(&dirs, &shells, &cli.tools, cli.new_only)
         }
     }
 }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -196,6 +196,53 @@ fn get_installed_tools() -> Result<std::collections::HashMap<String, String>, Er
     Ok(tool_map)
 }
 
+/// Get newly installed/updated tools from MISE_INSTALLED_TOOLS environment variable
+/// Format: [{"name":"node","version":"20.10.0"},{"name":"python","version":"3.12.0"}]
+/// Returns empty HashMap if env var is not set (no newly installed tools)
+/// Returns a map of stripped tool names to their original IDs (same format as get_installed_tools)
+fn get_newly_installed_tools() -> Result<std::collections::HashMap<String, String>, Error> {
+    let installed_tools_json = match std::env::var("MISE_INSTALLED_TOOLS") {
+        Ok(val) => val,
+        Err(_) => return Ok(std::collections::HashMap::new()), // Env var not set means no new tools
+    };
+
+    parse_installed_tools_json(&installed_tools_json)
+}
+
+/// Parse the MISE_INSTALLED_TOOLS JSON string and extract tool names
+/// Returns a map of stripped tool names to their original IDs (with backend prefixes)
+fn parse_installed_tools_json(
+    json: &str,
+) -> Result<std::collections::HashMap<String, String>, Error> {
+    let tools: serde_json::Value = serde_json::from_str(json)
+        .map_err(|e| Error::MiseList(format!("failed to parse MISE_INSTALLED_TOOLS: {e}")))?;
+
+    let mut tool_map = std::collections::HashMap::new();
+
+    if let Some(arr) = tools.as_array() {
+        for item in arr {
+            if let (Some(name), Some(_version)) = (item.get("name"), item.get("version")) {
+                if let Some(s) = name.as_str() {
+                    // Use the same extract_tool_name logic as get_installed_tools
+                    let short_name = extract_tool_name(s);
+                    let is_bare = !s.contains(':');
+                    match tool_map.entry(short_name) {
+                        std::collections::hash_map::Entry::Vacant(e) => {
+                            e.insert(s.to_string());
+                        }
+                        std::collections::hash_map::Entry::Occupied(mut e) if is_bare => {
+                            e.insert(s.to_string());
+                        }
+                        std::collections::hash_map::Entry::Occupied(_) => {}
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(tool_map)
+}
+
 /// Generate completion for a single tool and shell
 fn generate_completion(
     tool_id: &str,   // Original ID with backend prefix (for mise x)
@@ -234,13 +281,19 @@ pub fn sync_completions(
     dirs: &CompletionsDirs,
     shells: &[String],
     specific_tools: &[String],
+    new_only: bool,
 ) -> Result<(), Error> {
     let registry = registry::load_registry()?;
 
     // Determine which tools to sync
     let tools_map: std::collections::HashMap<String, String> = if specific_tools.is_empty() {
-        // Get all installed tools from mise (maps short name -> original ID)
-        get_installed_tools()?
+        if new_only {
+            // Only sync newly installed tools from MISE_INSTALLED_TOOLS env var
+            get_newly_installed_tools()?
+        } else {
+            // Get all installed tools from mise (maps short name -> original ID)
+            get_installed_tools()?
+        }
     } else {
         // For specific tools, short name equals original ID
         specific_tools
@@ -517,5 +570,53 @@ mod tests {
         );
         // Single component after colon
         assert_eq!(extract_tool_name("aqua:simple-tool"), "simple-tool");
+    }
+
+    #[test]
+    fn test_get_newly_installed_tools_empty_when_env_not_set() {
+        // Ensure env var is not set
+        std::env::remove_var("MISE_INSTALLED_TOOLS");
+        let tools = get_newly_installed_tools().expect("should return empty HashMap");
+        assert!(tools.is_empty());
+    }
+
+    #[test]
+    fn test_parse_installed_tools_json_parses_correctly() {
+        let json = r#"[{"name":"node","version":"20.10.0"},{"name":"python","version":"3.12.0"}]"#;
+        let tools = parse_installed_tools_json(json).expect("should parse JSON");
+        assert_eq!(tools.get("node"), Some(&"node".to_string()));
+        assert_eq!(tools.get("python"), Some(&"python".to_string()));
+    }
+
+    #[test]
+    fn test_parse_installed_tools_json_handles_backend_prefixes() {
+        let json = r#"[{"name":"go:golang.org/x/tools/gopls","version":"0.12.0"},{"name":"aqua:reteps/dockerfmt","version":"1.0.0"}]"#;
+        let tools = parse_installed_tools_json(json).expect("should extract binary names");
+        assert_eq!(
+            tools.get("gopls"),
+            Some(&"go:golang.org/x/tools/gopls".to_string())
+        );
+        assert_eq!(
+            tools.get("dockerfmt"),
+            Some(&"aqua:reteps/dockerfmt".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_installed_tools_json_empty_array() {
+        let json = "[]";
+        let tools = parse_installed_tools_json(json).expect("should return empty HashMap");
+        assert!(tools.is_empty());
+    }
+
+    #[test]
+    fn test_parse_installed_tools_json_invalid_json() {
+        let json = "invalid json";
+        let result = parse_installed_tools_json(json);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("failed to parse MISE_INSTALLED_TOOLS"));
     }
 }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -306,7 +306,11 @@ pub fn sync_completions(
     tools_in_registry.sort_by(|a, b| a.0.cmp(b.0));
 
     if tools_in_registry.is_empty() {
-        println!("No newly-installed tools have completion support in registry.");
+        if new_only {
+            println!("No newly-installed tools have completion support in registry.");
+        } else {
+            println!("No installed tools have completion support in registry.");
+        }
         return Ok(());
     }
 

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -209,6 +209,27 @@ fn get_newly_installed_tools() -> Result<std::collections::HashMap<String, Strin
     parse_installed_tools_json(&installed_tools_json)
 }
 
+/// Extract binary name from tool name (handles backend prefixes like "go:" or "aqua:")
+/// Examples:
+/// - "go:golang.org/x/tools/gopls" -> "gopls"
+/// - "aqua:reteps/dockerfmt" -> "dockerfmt"
+/// - "github:GoogleCloudPlatform/kubectl-ai" -> "kubectl-ai"
+/// - "yq" -> "yq" (no prefix, keep as-is)
+fn extract_binary_name(tool_name: &str) -> String {
+    if let Some(colon_pos) = tool_name.find(':') {
+        // Has backend prefix, extract the last component after the last slash
+        let after_colon = &tool_name[colon_pos + 1..];
+        after_colon
+            .rsplit('/')
+            .next()
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| after_colon.to_string())
+    } else {
+        // No backend prefix, use as-is
+        tool_name.to_string()
+    }
+}
+
 /// Parse the MISE_INSTALLED_TOOLS JSON string and extract tool names
 /// Returns a map of stripped tool names to their original IDs (with backend prefixes)
 fn parse_installed_tools_json(
@@ -570,6 +591,35 @@ mod tests {
         );
         // Single component after colon
         assert_eq!(extract_tool_name("aqua:simple-tool"), "simple-tool");
+    }
+
+    #[test]
+    fn test_extract_binary_name_no_prefix() {
+        assert_eq!(extract_binary_name("yq"), "yq");
+        assert_eq!(extract_binary_name("kubectl"), "kubectl");
+    }
+
+    #[test]
+    fn test_extract_binary_name_go_backend() {
+        assert_eq!(extract_binary_name("go:golang.org/x/tools/gopls"), "gopls");
+        assert_eq!(extract_binary_name("go:example.com/tool"), "tool");
+    }
+
+    #[test]
+    fn test_extract_binary_name_aqua_backend() {
+        assert_eq!(extract_binary_name("aqua:reteps/dockerfmt"), "dockerfmt");
+        assert_eq!(
+            extract_binary_name("aqua:owner/repo/tool_name"),
+            "tool_name"
+        );
+    }
+
+    #[test]
+    fn test_extract_binary_name_github_backend() {
+        assert_eq!(
+            extract_binary_name("github:GoogleCloudPlatform/kubectl-ai"),
+            "kubectl-ai"
+        );
     }
 
     #[test]

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -201,12 +201,13 @@ fn get_installed_tools() -> Result<std::collections::HashMap<String, String>, Er
 
 /// Get newly installed/updated tools from MISE_INSTALLED_TOOLS environment variable
 /// Format: [{"name":"node","version":"20.10.0"},{"name":"python","version":"3.12.0"}]
-/// Returns empty HashMap if env var is not set (no newly installed tools)
+/// Returns empty HashMap if env var is not set or empty (no newly installed tools)
 /// Returns a map of stripped tool names to their original IDs (same format as get_installed_tools)
 fn get_newly_installed_tools() -> Result<std::collections::HashMap<String, String>, Error> {
     let installed_tools_json = match std::env::var("MISE_INSTALLED_TOOLS") {
-        Ok(val) => val,
-        Err(_) => return Ok(std::collections::HashMap::new()), // Env var not set means no new tools
+        Ok(val) if !val.is_empty() => val,
+        Ok(_) => return Ok(std::collections::HashMap::new()), // Empty string = no new tools
+        Err(_) => return Ok(std::collections::HashMap::new()), // Env var not set
     };
 
     parse_installed_tools_json(&installed_tools_json)
@@ -224,7 +225,7 @@ fn parse_installed_tools_json(
 
     if let Some(arr) = tools.as_array() {
         for item in arr {
-            if let (Some(name), Some(_version)) = (item.get("name"), item.get("version")) {
+            if let Some(name) = item.get("name") {
                 if let Some(s) = name.as_str() {
                     resolve_tool_binary(&mut tool_map, s);
                 }
@@ -305,7 +306,7 @@ pub fn sync_completions(
     tools_in_registry.sort_by(|a, b| a.0.cmp(b.0));
 
     if tools_in_registry.is_empty() {
-        println!("No installed tools have completion support in registry.");
+        println!("No newly-installed tools have completion support in registry.");
         return Ok(());
     }
 
@@ -565,14 +566,6 @@ mod tests {
     }
 
     #[test]
-    fn test_get_newly_installed_tools_empty_when_env_not_set() {
-        // Ensure env var is not set
-        std::env::remove_var("MISE_INSTALLED_TOOLS");
-        let tools = get_newly_installed_tools().expect("should return empty HashMap");
-        assert!(tools.is_empty());
-    }
-
-    #[test]
     fn test_parse_installed_tools_json_parses_correctly() {
         let json = r#"[{"name":"node","version":"20.10.0"},{"name":"python","version":"3.12.0"}]"#;
         let tools = parse_installed_tools_json(json).expect("should parse JSON");
@@ -581,17 +574,12 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_installed_tools_json_handles_backend_prefixes() {
-        let json = r#"[{"name":"go:golang.org/x/tools/gopls","version":"0.12.0"},{"name":"aqua:reteps/dockerfmt","version":"1.0.0"}]"#;
-        let tools = parse_installed_tools_json(json).expect("should extract binary names");
-        assert_eq!(
-            tools.get("gopls"),
-            Some(&"go:golang.org/x/tools/gopls".to_string())
-        );
-        assert_eq!(
-            tools.get("dockerfmt"),
-            Some(&"aqua:reteps/dockerfmt".to_string())
-        );
+    fn test_parse_installed_tools_json_short_names() {
+        let json =
+            r#"[{"name":"gopls","version":"0.12.0"},{"name":"dockerfmt","version":"1.0.0"}]"#;
+        let tools = parse_installed_tools_json(json).expect("should parse short names");
+        assert_eq!(tools.get("gopls"), Some(&"gopls".to_string()));
+        assert_eq!(tools.get("dockerfmt"), Some(&"dockerfmt".to_string()));
     }
 
     #[test]

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -151,6 +151,22 @@ fn extract_tool_name(tool_id: &str) -> String {
     }
 }
 
+// When two installed tools resolve to the same short name (e.g. "kubectl" and
+// "aqua:org/kubectl"), prefer the bare entry — it's the one most likely to be on PATH.
+fn resolve_tool_binary(tool_map: &mut std::collections::HashMap<String, String>, tool_id: &str) {
+    let short_name = extract_tool_name(tool_id);
+    let is_bare = !tool_id.contains(':');
+    match tool_map.entry(short_name) {
+        std::collections::hash_map::Entry::Vacant(e) => {
+            e.insert(tool_id.to_string());
+        }
+        std::collections::hash_map::Entry::Occupied(mut e) if is_bare => {
+            e.insert(tool_id.to_string());
+        }
+        std::collections::hash_map::Entry::Occupied(_) => {}
+    }
+}
+
 /// Get list of installed tools from mise
 /// Returns a map of stripped tool names to their original IDs (with backend prefixes)
 /// This allows registry matching on short names while preserving the original ID for mise x
@@ -173,23 +189,10 @@ fn get_installed_tools() -> Result<std::collections::HashMap<String, String>, Er
     // Tool names may include backend prefixes like "go:package" or "aqua:repo/tool"
     // We need to extract the actual binary name for registry matching
     // but keep the original ID for mise x operations.
-    //
-    // When two installed tools resolve to the same short name (e.g. "kubectl" and
-    // "aqua:org/kubectl"), prefer the bare entry — it's the one most likely to be on PATH.
     let mut tool_map = std::collections::HashMap::new();
     if let Some(obj) = tools.as_object() {
         for tool_id in obj.keys() {
-            let short_name = extract_tool_name(tool_id);
-            let is_bare = !tool_id.contains(':');
-            match tool_map.entry(short_name) {
-                std::collections::hash_map::Entry::Vacant(e) => {
-                    e.insert(tool_id.to_string());
-                }
-                std::collections::hash_map::Entry::Occupied(mut e) if is_bare => {
-                    e.insert(tool_id.to_string());
-                }
-                std::collections::hash_map::Entry::Occupied(_) => {}
-            }
+            resolve_tool_binary(&mut tool_map, tool_id);
         }
     }
 
@@ -209,27 +212,6 @@ fn get_newly_installed_tools() -> Result<std::collections::HashMap<String, Strin
     parse_installed_tools_json(&installed_tools_json)
 }
 
-/// Extract binary name from tool name (handles backend prefixes like "go:" or "aqua:")
-/// Examples:
-/// - "go:golang.org/x/tools/gopls" -> "gopls"
-/// - "aqua:reteps/dockerfmt" -> "dockerfmt"
-/// - "github:GoogleCloudPlatform/kubectl-ai" -> "kubectl-ai"
-/// - "yq" -> "yq" (no prefix, keep as-is)
-fn extract_binary_name(tool_name: &str) -> String {
-    if let Some(colon_pos) = tool_name.find(':') {
-        // Has backend prefix, extract the last component after the last slash
-        let after_colon = &tool_name[colon_pos + 1..];
-        after_colon
-            .rsplit('/')
-            .next()
-            .map(|s| s.to_string())
-            .unwrap_or_else(|| after_colon.to_string())
-    } else {
-        // No backend prefix, use as-is
-        tool_name.to_string()
-    }
-}
-
 /// Parse the MISE_INSTALLED_TOOLS JSON string and extract tool names
 /// Returns a map of stripped tool names to their original IDs (with backend prefixes)
 fn parse_installed_tools_json(
@@ -244,18 +226,7 @@ fn parse_installed_tools_json(
         for item in arr {
             if let (Some(name), Some(_version)) = (item.get("name"), item.get("version")) {
                 if let Some(s) = name.as_str() {
-                    // Use the same extract_tool_name logic as get_installed_tools
-                    let short_name = extract_tool_name(s);
-                    let is_bare = !s.contains(':');
-                    match tool_map.entry(short_name) {
-                        std::collections::hash_map::Entry::Vacant(e) => {
-                            e.insert(s.to_string());
-                        }
-                        std::collections::hash_map::Entry::Occupied(mut e) if is_bare => {
-                            e.insert(s.to_string());
-                        }
-                        std::collections::hash_map::Entry::Occupied(_) => {}
-                    }
+                    resolve_tool_binary(&mut tool_map, s);
                 }
             }
         }
@@ -591,35 +562,6 @@ mod tests {
         );
         // Single component after colon
         assert_eq!(extract_tool_name("aqua:simple-tool"), "simple-tool");
-    }
-
-    #[test]
-    fn test_extract_binary_name_no_prefix() {
-        assert_eq!(extract_binary_name("yq"), "yq");
-        assert_eq!(extract_binary_name("kubectl"), "kubectl");
-    }
-
-    #[test]
-    fn test_extract_binary_name_go_backend() {
-        assert_eq!(extract_binary_name("go:golang.org/x/tools/gopls"), "gopls");
-        assert_eq!(extract_binary_name("go:example.com/tool"), "tool");
-    }
-
-    #[test]
-    fn test_extract_binary_name_aqua_backend() {
-        assert_eq!(extract_binary_name("aqua:reteps/dockerfmt"), "dockerfmt");
-        assert_eq!(
-            extract_binary_name("aqua:owner/repo/tool_name"),
-            "tool_name"
-        );
-    }
-
-    #[test]
-    fn test_extract_binary_name_github_backend() {
-        assert_eq!(
-            extract_binary_name("github:GoogleCloudPlatform/kubectl-ai"),
-            "kubectl-ai"
-        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This PR adds a new `--new-only` flag to `mise-completions-sync` that only generates completions for newly installed or updated tools by reading the `MISE_INSTALLED_TOOLS` environment variable. This is useful for postinstall hooks where you only want to update completions for tools that were just installed/updated.

Documentation: https://mise.jdx.dev/hooks.html#preinstall-postinstall-hook

Please tell me if you'd rather use another flag name.

## Changes

   - Added `--new-only` flag that reads `MISE_INSTALLED_TOOLS` env var
   - Updated README with usage example

## Testing

- Added unit tests for the new JSON parsing functionality
- Verified the flag works with both set and unset environment variables


Signed-off-by: Baptiste ROUX <arte.but.posix@gmail.com>