### PR TITLE
fix(ci): restore x86_64-unknown-linux-musl release binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,8 @@ jobs:
             os: ubuntu-latest
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Re-adds `x86_64-unknown-linux-musl` to the release build matrix so distros with older glibc (e.g., Ubuntu 22.04 ships glibc 2.35) can run the prebuilt binary.
- The gnu binary built on `ubuntu-latest` links against the runner's glibc (currently 2.39); the musl tarball restores the portable, statically-linked fallback that v0.5.1 had before #63 consolidated the release pipeline.
- Brew formula job is unchanged — Homebrew on Linux uses glibc, so the gnu variant stays correct there.

Closes #89

## Test plan
- [ ] Next release publishes a `mise-completions-sync-x86_64-unknown-linux-musl.tar.gz` asset
- [ ] Extracted `misecompsync` from that tarball runs `--help` on Ubuntu 22.04 without GLIBC errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)