### PR TITLE
fix: use standard pattern for lefthook

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -84,6 +84,7 @@ golangci-lint = "standard"
 goreleaser = "standard"
 hugo = "standard"
 lazygit = "standard"
+lefthook = "standard"
 oc = "standard"
 pitchfork = "standard"
 pulumi = "standard"
@@ -93,9 +94,6 @@ saml2aws = "standard"
 step = "standard"
 xh = "standard"
 yq = "standard"
-
-# Lefthook uses completions pattern
-lefthook = "completions"
 
 # Tools with explicit commands (unique patterns or partial shell support)
 


### PR DESCRIPTION
## Summary
- lefthook's command is `completion {shell}` (singular), not `completions`, so the registry entry for lefthook was invoking `lefthook completions bash`, which prints `No help topic for 'completions'` instead of the completion script
- Switches lefthook from the `completions` pattern to `standard`

Closes #86

## Test plan
- [x] `cargo test` passes
- [x] Verified `lefthook completion {zsh,bash,fish}` all emit valid completion scripts (lefthook 2.1.8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)