### PR TITLE
feat: self shell completions (closes #75)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,6 +87,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7a9bfdb35811f9e59832f0f05975114d2251b415fb534108e6f34060fd772"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,6 +218,7 @@ name = "mise-completions-sync"
 version = "0.5.7"
 dependencies = [
  "clap",
+ "clap_complete",
  "dirs",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["command-line-utilities", "development-tools"]
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
+clap_complete = "4"
 serde = { version = "1", features = ["derive"] }
 toml = "1.0"
 dirs = "6"

--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ misecompsync list
 
 # Clean up completions for uninstalled tools
 misecompsync clean
+
+# Print misecompsync's own completions to stdout
+misecompsync completion zsh
 ```
 
 ### Automatic sync

--- a/registry.toml
+++ b/registry.toml
@@ -97,6 +97,10 @@ yq = "standard"
 
 # Tools with explicit commands (unique patterns or partial shell support)
 
+# mise installs this tool as github:alltuner/mise-completions-sync (stripped to "mise-completions-sync"),
+# but the binary it provides is named misecompsync.
+mise-completions-sync = { zsh = "misecompsync completion zsh", bash = "misecompsync completion bash", fish = "misecompsync completion fish" }
+
 bun = { zsh = "bun completions", bash = "bun completions", fish = "bun completions" }
 
 # Partial shell support (zsh + bash)

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,8 @@ mod registry;
 mod shells;
 mod sync;
 
-use clap::{Parser, Subcommand};
+use clap::{CommandFactory, Parser, Subcommand};
+use clap_complete::Shell;
 
 #[derive(Parser)]
 #[command(name = "misecompsync")]
@@ -36,6 +37,11 @@ enum Commands {
     },
     /// Remove completions for tools no longer installed
     Clean,
+    /// Print shell completions for misecompsync itself to stdout
+    Completion {
+        /// Shell to generate completions for
+        shell: Shell,
+    },
 }
 
 fn main() {
@@ -64,6 +70,12 @@ fn run() -> Result<(), sync::Error> {
             Ok(())
         }
         Some(Commands::Clean) => sync::clean_stale_completions(&dirs),
+        Some(Commands::Completion { shell }) => {
+            let mut cmd = Cli::command();
+            let bin_name = cmd.get_name().to_string();
+            clap_complete::generate(shell, &mut cmd, bin_name, &mut std::io::stdout());
+            Ok(())
+        }
         None => {
             let shells = cli
                 .shell

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -148,4 +148,16 @@ mod tests {
             Some("prek util generate-shell-completion fish")
         );
     }
+
+    #[test]
+    fn test_self_in_registry() {
+        let registry = load_registry().expect("Failed to load registry");
+        let entry = registry
+            .tools
+            .get("mise-completions-sync")
+            .expect("mise-completions-sync should be in registry");
+        assert_eq!(entry.zsh.as_deref(), Some("misecompsync completion zsh"));
+        assert_eq!(entry.bash.as_deref(), Some("misecompsync completion bash"));
+        assert_eq!(entry.fish.as_deref(), Some("misecompsync completion fish"));
+    }
 }


### PR DESCRIPTION
## Summary

- Add `misecompsync completion <shell>` subcommand using `clap_complete` (zsh/bash/fish/elvish/powershell — sync only consumes the first three).
- Register `mise-completions-sync` in the embedded registry pointing at that subcommand, so the tool can sync its own completions like any other.

The registry key has to be `mise-completions-sync` because that's the stripped name `extract_tool_name` produces from `github:alltuner/mise-completions-sync`. The actual binary it dispatches to is `misecompsync`. The generated file's `#compdef misecompsync` directive (and bash/fish equivalents) hooks the completion to the real binary name regardless of filename.

`docs/tools.md` is generator-managed and picks up unrelated drift, so it's left for a future docs regeneration pass.

## Test plan

- [x] `cargo test` — 17/17 passing (added `test_self_in_registry`)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `misecompsync completion zsh|bash|fish` each produce valid completion script output
- [ ] After install via `mise use -g github:alltuner/mise-completions-sync`, `misecompsync` picks up the entry from `mise ls` and writes `_mise-completions-sync` (zsh) / `mise-completions-sync` (bash) / `mise-completions-sync.fish` (fish)