### PR TITLE
feat: add talosctl

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -35,6 +35,7 @@ kubeseal = "standard"
 linkerd = "standard"
 skaffold = "standard"
 stern = "standard"
+talosctl = "standard"
 tilt = "standard"
 velero = "standard"
 


### PR DESCRIPTION
## Summary
- Add `talosctl` (Talos Linux CLI) to the registry using the `standard` completion pattern.
- Verified via `mise x talosctl -- talosctl completion {zsh,bash,fish}` — all three shells emit valid completion scripts.
- Confirmed in mise's registry as `aqua:siderolabs/talos`.

Supersedes #93 (credit to @lukasgierth for the original contribution).

## Test plan
- [x] `uv run scripts/validate-registry.py --installed-only` — talosctl passes
- [x] Inspected generated zsh/bash/fish completion output

🤖 Generated with [Claude Code](https://claude.com/claude-code)