### PR TITLE
fix(registry): remove fzf and zoxide (closes #78)

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -5,7 +5,7 @@ Use this to identify tools that could be added to mise-completions-sync.
 
 ## Supported Tools
 
-Currently **89 tools** have completion support.
+Currently **93 tools** have completion support.
 
 See [docs/tools.md](docs/tools.md) for the full list with shell support details.
 
@@ -66,7 +66,7 @@ These tools are in mise's registry but not yet supported. They may have completi
 | [aws-sso](https://github.com/synfinatic/aws-sso-cli) | A powerful tool for using AWS Identity Center f... | Needs testing |
 | [aws-vault](https://github.com/ByteNess/aws-vault) | A vault for securely storing and accessing AWS ... | Needs testing |
 
-*...and 811 more tools in mise registry*
+*...and 775 more tools in mise registry*
 
 ## Tools Without Completion Support
 
@@ -80,6 +80,7 @@ These tools have been tested and confirmed to NOT output shell completion script
 - **dust**: A more intuitive version of du in rust
 - **evans**: Evans: more expressive universal gRPC client
 - **eza**: A modern, maintained replacement for ls
+- **fzf**: :cherry_blossom: A command-line fuzzy finder
 - **gcloud**: GCloud CLI (Google Cloud SDK)
 - **nomad**: Nomad is an easy-to-use, flexible, and performa...
 - **terraform**: Terraform enables you to safely and predictably...
@@ -87,11 +88,11 @@ These tools have been tested and confirmed to NOT output shell completion script
 - **vault**: A tool for secrets management, encryption as a ...
 - **wrangler**: A command line tool for building Cloudflare Wor...
 - **yarn**: Yarn is a package manager that doubles down as ...
+- **zoxide**: A smarter cd command. Supports all major shells
 
 ## How to Add a Tool
 
 1. Check if the tool supports shell completions:
-
    ```bash
    mise x <tool> -- <tool> completion --help
    mise x <tool> -- <tool> --help | grep -i complet
@@ -100,7 +101,6 @@ These tools have been tested and confirmed to NOT output shell completion script
 2. Find the correct completion command pattern
 
 3. Add entry to `registry.toml`:
-
    ```toml
    # If it matches an existing pattern:
    newtool = "standard"  # for: newtool completion <shell>
@@ -110,7 +110,6 @@ These tools have been tested and confirmed to NOT output shell completion script
    ```
 
 4. Test the entry:
-
    ```bash
    uv run scripts/validate-registry.py --installed-only
    ```

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -39,10 +39,10 @@ You can override the default output directory using the `MISE_COMPLETIONS_SYNC_H
 ```shell
 export MISE_COMPLETIONS_SYNC_HOME="$XDG_DATA_HOME/custom-vendor-completions"
 
-mise-completions-sync fzf
-#  [fish] -> ~/.local/share/custom-vendor-completions/fish/fzf.fish
-#  [zsh]  -> ~/.local/share/custom-vendor-completions/zsh/_fzf
-#  [bash] -> ~/.local/share/custom-vendor-completions/bash/fzf
+mise-completions-sync kubectl
+#  [fish] -> ~/.local/share/custom-vendor-completions/fish/kubectl.fish
+#  [zsh]  -> ~/.local/share/custom-vendor-completions/zsh/_kubectl
+#  [bash] -> ~/.local/share/custom-vendor-completions/bash/kubectl
 ```
 
 Or you can override output directories for one (or more) shells (e.g., `MISE_COMPLETIONS_SYNC_{SHELL}_DIR`)
@@ -50,10 +50,10 @@ Or you can override output directories for one (or more) shells (e.g., `MISE_COM
 ```shell
 export MISE_COMPLETIONS_SYNC_FISH_DIR="$XDG_CONFIG_HOME/fish/completions"
 
-mise-completions-sync fzf
-#  [fish] -> ~/.config/fish/completions/fzf.fish
-#  [zsh]  -> ~/.local/share/mise-completions/zsh/_fzf
-#  [bash] -> ~/.local/share/mise-completions/bash/fzf
+mise-completions-sync kubectl
+#  [fish] -> ~/.config/fish/completions/kubectl.fish
+#  [zsh]  -> ~/.local/share/mise-completions/zsh/_kubectl
+#  [bash] -> ~/.local/share/mise-completions/bash/kubectl
 ```
 
 Or a shell dir with base dir default (shell takes precedence):
@@ -62,10 +62,10 @@ Or a shell dir with base dir default (shell takes precedence):
 export MISE_COMPLETIONS_SYNC_HOME="$XDG_DATA_HOME/custom-vendor-completions"
 export MISE_COMPLETIONS_SYNC_ZSH_DIR="$XDG_DATA_HOME/zsh/site-functions"
 
-mise-completions-sync fzf
-#  [fish] -> ~/.local/share/custom-vendor-completions/fish/fzf.fish
-#  [zsh]  -> ~/.local/share/zsh/site-functions/_fzf
-#  [bash] -> ~/.local/share/custom-vendor-completions/bash/fzf
+mise-completions-sync kubectl
+#  [fish] -> ~/.local/share/custom-vendor-completions/fish/kubectl.fish
+#  [zsh]  -> ~/.local/share/zsh/site-functions/_kubectl
+#  [bash] -> ~/.local/share/custom-vendor-completions/bash/kubectl
 ```
 
 Note: Target directories will be created if they don't already exist.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -26,7 +26,6 @@ The following tools have shell completion support in mise-completions-sync.
 | flux |  | ✓ | ✓ | ✓ |
 | [flyctl](https://github.com/superfly/flyctl) | Command line tools for fly.io services | ✓ | ✓ | ✓ |
 | fnox | Fort Knox for your secrets | ✓ | ✓ | ✓ |
-| [fzf](https://github.com/junegunn/fzf) | :cherry_blossom: A command-line fuzzy finder | ✓ | ✓ | ✓ |
 | [gh](https://github.com/cli/cli) | GitHub’s official command line tool | ✓ | ✓ | ✓ |
 | [gitleaks](https://github.com/gitleaks/gitleaks) | Find secrets with Gitleaks | ✓ | ✓ | ✓ |
 | [gitu](https://github.com/altsem/gitu) | A TUI Git client inspired by Magit | ✓ | ✓ | ✓ |
@@ -54,9 +53,10 @@ The following tools have shell completion support in mise-completions-sync.
 | [mdbook](https://github.com/rust-lang/mdBook) | Create book from markdown files. Like Gitbook b... | ✓ | ✓ | ✓ |
 | [minikube](https://github.com/kubernetes/minikube) | Run Kubernetes locally | ✓ | ✓ | ✓ |
 | mise |  | ✓ | ✓ | ✓ |
+| mise-completions-sync |  | ✓ | ✓ | ✓ |
 | [nerdctl](https://github.com/containerd/nerdctl) | contaiNERD CTL - Docker-compatible CLI for cont... | ✓ | ✓ | ✓ |
 | nix |  | ✓ | ✓ | ✓ |
-| npm | the package manager for JavaScript | ✓ | ✓ |  |
+| [npm](https://github.com/npm/cli) | the package manager for JavaScript | ✓ | ✓ |  |
 | oc | OpenShift Client CLI (oc) | ✓ | ✓ | ✓ |
 | oci | Oracle Cloud Infrastructure CLI | ✓ | ✓ | ✓ |
 | [oras](https://github.com/oras-project/oras) | ORAS CLI | ✓ | ✓ | ✓ |
@@ -83,10 +83,13 @@ The following tools have shell completion support in mise-completions-sync.
 | [step](https://github.com/smallstep/cli) | A zero trust swiss army knife for working with ... | ✓ | ✓ | ✓ |
 | [stern](https://github.com/stern/stern) | ⎈ Multi pod and container log tailing for Kuber... | ✓ | ✓ | ✓ |
 | [syft](https://github.com/anchore/syft) | CLI tool and library for generating a Software ... | ✓ | ✓ | ✓ |
+| [talosctl](https://github.com/siderolabs/talos) | Talos is a modern OS for Kubernetes. talosctl i... | ✓ | ✓ | ✓ |
 | [task](https://github.com/go-task/task) | A task runner / simpler Make alternative writte... | ✓ | ✓ | ✓ |
 | [tilt](https://github.com/tilt-dev/tilt) | Define your dev environment as code. For micros... | ✓ | ✓ | ✓ |
+| [tree-sitter](https://github.com/tree-sitter/tree-sitter) | An incremental parsing system for programming t... | ✓ | ✓ | ✓ |
 | [trivy](https://github.com/aquasecurity/trivy) | Find vulnerabilities, misconfigurations, secret... | ✓ | ✓ | ✓ |
 | [ty](https://github.com/astral-sh/ty) | An extremely fast Python type checker and langu... | ✓ | ✓ | ✓ |
+| [usage](https://github.com/jdx/usage) | A specification for CLIs | ✓ | ✓ | ✓ |
 | [uv](https://github.com/astral-sh/uv) | An extremely fast Python package installer and ... | ✓ | ✓ | ✓ |
 | [velero](https://github.com/vmware-tanzu/velero) | Backup and migrate Kubernetes applications and ... | ✓ | ✓ | ✓ |
 | vercel | Build and deploy on the Vercel cloud | ✓ | ✓ |  |
@@ -94,9 +97,8 @@ The following tools have shell completion support in mise-completions-sync.
 | [xh](https://github.com/ducaale/xh) | Friendly and fast tool for sending HTTP requests | ✓ | ✓ | ✓ |
 | [yq](https://github.com/mikefarah/yq) | yq is a portable command-line YAML processor | ✓ | ✓ | ✓ |
 | [zellij](https://github.com/zellij-org/zellij) | A terminal workspace with batteries included | ✓ | ✓ | ✓ |
-| [zoxide](https://github.com/ajeetdsouza/zoxide) | A smarter cd command. Supports all major shells | ✓ | ✓ | ✓ |
 
-**Total: 89 tools**
+**Total: 93 tools**
 
 ## Shell Support Legend
 

--- a/registry.toml
+++ b/registry.toml
@@ -135,12 +135,6 @@ scaleway-cli = { zsh = "scw autocomplete script shell=zsh", bash = "scw autocomp
 rg = { zsh = "rg --generate complete-zsh", bash = "rg --generate complete-bash", fish = "rg --generate complete-fish" }
 ripgrep = { zsh = "rg --generate complete-zsh", bash = "rg --generate complete-bash", fish = "rg --generate complete-fish" }
 
-# zoxide uses init instead of completion
-zoxide = { zsh = "zoxide init zsh", bash = "zoxide init bash", fish = "zoxide init fish" }
-
-# fzf has unique shell flags
-fzf = { zsh = "fzf --zsh", bash = "fzf --bash", fish = "fzf --fish" }
-
 # nix needs extra experimental features flag
 nix = { zsh = "nix --extra-experimental-features 'nix-command' completion zsh 2>/dev/null || true", bash = "nix --extra-experimental-features 'nix-command' completion bash 2>/dev/null || true", fish = "nix --extra-experimental-features 'nix-command' completion fish 2>/dev/null || true" }
 

--- a/scripts/generate-tools-status.py
+++ b/scripts/generate-tools-status.py
@@ -25,6 +25,7 @@ NO_COMPLETION_SUPPORT = {
     "croc",
     "dust",
     "evans",
+    "fzf",  # Ships shell integration script (key bindings), not a completion file
     "gcloud",  # Completions bundled as files in SDK, not generated via command
     "eza",
     "nomad",  # HashiCorp autocomplete-install pattern
@@ -33,6 +34,7 @@ NO_COMPLETION_SUPPORT = {
     "vault",  # HashiCorp autocomplete-install pattern
     "wrangler",
     "yarn",  # Requires project context
+    "zoxide",  # Ships shell init script (hooks), not a completion file
 }
 
 # Common completion patterns to check


### PR DESCRIPTION
## Summary
- `fzf --{shell}` and `zoxide init {shell}` produce shell *integration* scripts (key bindings, hooks) intended to be eval'd from a shell rc, not completion files — generated zsh files lack `#compdef`, and the bash/fish variants are the same kind of init script.
- Drops both tools from `registry.toml` and lists them under `TOOLS.md`'s "Tools Without Completion Support" section.
- Swaps the `fzf` example in `docs/how-it-works.md` for `kubectl`. Regenerated `TOOLS.md` and `docs/tools.md` (picks up some unrelated drift from recent registry additions that hadn't been re-run yet).

Closes #78.

## Test plan
- [x] `cargo test` passes
- [x] `mise run docs-status` / `docs-tools` regenerated cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)