### PR TITLE
fix(registry): remove kubectx (closes #104)

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -5,7 +5,7 @@ Use this to identify tools that could be added to mise-completions-sync.
 
 ## Supported Tools
 
-Currently **93 tools** have completion support.
+Currently **92 tools** have completion support.
 
 See [docs/tools.md](docs/tools.md) for the full list with shell support details.
 
@@ -55,8 +55,8 @@ These tools are in mise's registry but not yet supported. They may have completi
 | [atlas](https://github.com/ariga/atlas) | A modern tool for managing database schemas | Needs testing |
 | [atlas-community](https://github.com/ariga/atlas) | A modern tool for managing database schemas (Co... | Needs testing |
 | [atmos](https://github.com/cloudposse/atmos) | Workflow automation tool for DevOps. Keep confi... | Needs testing |
-| aube | A fast Node.js package manager | Needs testing |
-| auto-doc | Github action that turns your reusable workflow... | Needs testing |
+| [aube](https://github.com/endevco/aube) | A fast Node.js package manager | Needs testing |
+| auto-doc | GitHub action that turns your reusable workflow... | Needs testing |
 | aws-amplify | The AWS Amplify CLI is a toolchain for simplify... | Needs testing |
 | [aws-cli](https://github.com/aws/aws-cli) | The AWS Command Line Interface (AWS CLI v2) is ... | Needs testing |
 | [aws-copilot](https://github.com/aws/copilot-cli) | The AWS Copilot CLI is a tool for developers to... | Needs testing |
@@ -66,7 +66,7 @@ These tools are in mise's registry but not yet supported. They may have completi
 | [aws-sso](https://github.com/synfinatic/aws-sso-cli) | A powerful tool for using AWS Identity Center f... | Needs testing |
 | [aws-vault](https://github.com/ByteNess/aws-vault) | A vault for securely storing and accessing AWS ... | Needs testing |
 
-*...and 775 more tools in mise registry*
+*...and 781 more tools in mise registry*
 
 ## Tools Without Completion Support
 
@@ -82,6 +82,7 @@ These tools have been tested and confirmed to NOT output shell completion script
 - **eza**: A modern, maintained replacement for ls
 - **fzf**: :cherry_blossom: A command-line fuzzy finder
 - **gcloud**: GCloud CLI (Google Cloud SDK)
+- **kubectx**: Faster way to switch between clusters and names...
 - **nomad**: Nomad is an easy-to-use, flexible, and performa...
 - **terraform**: Terraform enables you to safely and predictably...
 - **tokei**: Count your code, quickly

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -44,7 +44,6 @@ The following tools have shell completion support in mise-completions-sync.
 | [ko](https://github.com/ko-build/ko) | Build and deploy Go applications on Kubernetes | ✓ | ✓ | ✓ |
 | [kubectl](https://github.com/kubernetes/kubernetes) | kubectl cli | ✓ | ✓ | ✓ |
 | kubectl-ai |  | ✓ | ✓ | ✓ |
-| [kubectx](https://github.com/ahmetb/kubectx) | Faster way to switch between clusters and names... | ✓ | ✓ |  |
 | [kubeseal](https://github.com/bitnami-labs/sealed-secrets) | A Kubernetes controller and tool for one-way en... | ✓ | ✓ | ✓ |
 | [kustomize](https://github.com/kubernetes-sigs/kustomize) | Customization of kubernetes YAML configurations | ✓ | ✓ | ✓ |
 | [lazygit](https://github.com/jesseduffield/lazygit) | simple terminal UI for git commands | ✓ | ✓ | ✓ |
@@ -60,7 +59,7 @@ The following tools have shell completion support in mise-completions-sync.
 | oc | OpenShift Client CLI (oc) | ✓ | ✓ | ✓ |
 | oci | Oracle Cloud Infrastructure CLI | ✓ | ✓ | ✓ |
 | [oras](https://github.com/oras-project/oras) | ORAS CLI | ✓ | ✓ | ✓ |
-| [pipx](https://github.com/pypa/pipx) |  | ✓ | ✓ |  |
+| [pipx](https://github.com/pypa/pipx) |  | ✓ | ✓ | ✓ |
 | [pitchfork](https://github.com/jdx/pitchfork) | Daemons with DX | ✓ | ✓ | ✓ |
 | [pluto](https://github.com/FairwindsOps/pluto) | A cli tool to help discover deprecated apiVersi... | ✓ | ✓ | ✓ |
 | [pnpm](https://github.com/pnpm/pnpm) | Fast, disk space efficient package manager | ✓ | ✓ |  |
@@ -98,7 +97,7 @@ The following tools have shell completion support in mise-completions-sync.
 | [yq](https://github.com/mikefarah/yq) | yq is a portable command-line YAML processor | ✓ | ✓ | ✓ |
 | [zellij](https://github.com/zellij-org/zellij) | A terminal workspace with batteries included | ✓ | ✓ | ✓ |
 
-**Total: 93 tools**
+**Total: 92 tools**
 
 ## Shell Support Legend
 

--- a/registry.toml
+++ b/registry.toml
@@ -111,7 +111,6 @@ bun = { zsh = "bun completions", bash = "bun completions", fish = "bun completio
 # Partial shell support (zsh + bash)
 npm = { zsh = "npm completion", bash = "npm completion" }
 pnpm = { zsh = "pnpm completion zsh", bash = "pnpm completion bash" }
-kubectx = { zsh = "kubectx completion zsh", bash = "kubectx completion bash" }
 vercel = { zsh = "vercel completion zsh", bash = "vercel completion bash" }
 sops = { zsh = "sops completion zsh", bash = "sops completion bash" }
 

--- a/scripts/generate-tools-status.py
+++ b/scripts/generate-tools-status.py
@@ -28,6 +28,7 @@ NO_COMPLETION_SUPPORT = {
     "fzf",  # Ships shell integration script (key bindings), not a completion file
     "gcloud",  # Completions bundled as files in SDK, not generated via command
     "eza",
+    "kubectx",  # No completion command (errors "too many arguments"); ships completion files instead
     "nomad",  # HashiCorp autocomplete-install pattern
     "terraform",  # HashiCorp autocomplete-install pattern
     "tokei",


### PR DESCRIPTION
## Problem

`kubectx` has no completion subcommand. The registry entry runs `kubectx completion <shell>`, which errors on every run:

```
$ mise x kubectx@latest -- kubectx completion zsh
error: too many arguments
```

Confirmed against kubectx 0.11.0. It ships static completion files in its repo rather than generating them via a command, so it can't be supported through the command-driven registry — same situation as `fzf` and `zoxide` (removed in #96) and `gcloud`.

## Change

- Remove `kubectx` from `registry.toml`.
- Add it to `NO_COMPLETION_SUPPORT` in `scripts/generate-tools-status.py` with a note.
- Regenerate `TOOLS.md` and `docs/tools.md` (count 93 → 92; the regen also reflects pipx's newly-merged fish support from #98).

## Testing

- `cargo test` — 17 passed.
- Verified `kubectx` no longer resolves in the loaded registry and is listed under "Tools Without Completion Support".

Closes #104.

🤖 Generated with [Claude Code](https://claude.com/claude-code)