### PR TITLE
fix(registry): correct restic completion command

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -93,7 +93,6 @@ lefthook = "standard"
 oc = "standard"
 pitchfork = "standard"
 pulumi = "standard"
-restic = "standard"
 rumdl = "completions"
 saml2aws = "standard"
 step = "standard"
@@ -139,3 +138,6 @@ nix = { zsh = "nix --extra-experimental-features 'nix-command' completion zsh 2>
 
 # tree-sitter has unique complete --shell {shell} pattern
 tree-sitter = { zsh = "tree-sitter complete --shell zsh", bash = "tree-sitter complete --shell bash", fish = "tree-sitter complete --shell fish" }
+
+# restic writes completions via `generate --{shell}-completion`; `-` sends them to stdout
+restic = { zsh = "restic generate --zsh-completion -", bash = "restic generate --bash-completion -", fish = "restic generate --fish-completion -" }


### PR DESCRIPTION
## Problem

`restic = "standard"` runs `restic completion <shell>`, which restic doesn't understand:

```
$ mise x restic@latest -- restic completion zsh
unknown command "completion" for "restic"
```

(Surfaced by `mise run validate-registry` while fixing #104 — restic happened to be installed locally.)

## Change

restic generates completions via `restic generate --{shell}-completion <file>`, where `-` means stdout. Replaced the `standard` reference with explicit commands:

```toml
restic = { zsh = "restic generate --zsh-completion -", bash = "restic generate --bash-completion -", fish = "restic generate --fish-completion -" }
```

## Testing

Verified all three against restic 0.18.1 (native `#compdef restic` for zsh, proper bash/fish scripts):

```
$ mise x restic@latest -- restic generate --zsh-completion -
#compdef restic
...
```

- `cargo test` — 17 passed.
- `mise run validate-registry` — 51/51 passed (was failing on restic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)