### PR TITLE
fix(registry): use right name for flux

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -23,7 +23,7 @@ The following tools have shell completion support in mise-completions-sync.
 | [doggo](https://github.com/mr-karan/doggo) | :dog: Command-line DNS Client for Humans. Writt... | ✓ | ✓ | ✓ |
 | [dyff](https://github.com/homeport/dyff) | A diff tool for YAML files, and sometimes JSON | ✓ | ✓ | ✓ |
 | [fd](https://github.com/sharkdp/fd) | A simple, fast and user-friendly alternative to... | ✓ | ✓ | ✓ |
-| flux |  | ✓ | ✓ | ✓ |
+| [flux2](https://github.com/fluxcd/flux2) | Open and extensible continuous delivery solutio... | ✓ | ✓ | ✓ |
 | [flyctl](https://github.com/superfly/flyctl) | Command line tools for fly.io services | ✓ | ✓ | ✓ |
 | fnox | Fort Knox for your secrets | ✓ | ✓ | ✓ |
 | [gh](https://github.com/cli/cli) | GitHub’s official command line tool | ✓ | ✓ | ✓ |

--- a/registry.toml
+++ b/registry.toml
@@ -28,7 +28,6 @@ kubectl-ai = "standard"
 minikube = "standard"
 kustomize = "standard"
 argocd = "standard"
-flux = "standard"
 istioctl = "standard"
 k3d = "standard"
 ko = "standard"
@@ -106,6 +105,9 @@ yq = "standard"
 mise-completions-sync = { zsh = "misecompsync completion zsh", bash = "misecompsync completion bash", fish = "misecompsync completion fish" }
 
 bun = { zsh = "bun completions", bash = "bun completions", fish = "bun completions" }
+
+# mise installs this tool as flux2, but the binary it provides is named flux.
+flux2 = { zsh = "flux completion zsh", bash = "flux completion bash", fish = "flux completion fish" }
 
 # Partial shell support (zsh + bash)
 npm = { zsh = "npm completion", bash = "npm completion" }

--- a/scripts/generate-registry.py
+++ b/scripts/generate-registry.py
@@ -31,7 +31,6 @@ TOOL_PATTERNS = {
     "minikube": "standard",
     "kustomize": "standard",
     "argocd": "standard",
-    "flux": "standard",
     "k3d": "standard",
     "kubeseal": "standard",
     "krew": "standard",


### PR DESCRIPTION
Hello,
This fix FluxCD command completions cause the tool is named [flux2](https://mise-versions.jdx.dev/tools/flux2) but CLI is  `flux`.
So, this PR simply map it correctly.

Thanks.