### PR TITLE
ci: run claude review on renovate PRs and skip forks

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,10 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # PRs from forks get a read-only token and no OIDC token, so the action
+    # cannot authenticate. Skip them instead of reporting a failed check that
+    # says nothing about the code.
+    if: github.event.pull_request.head.repo.fork == false
 
     runs-on: ubuntu-latest
     permissions:
@@ -36,6 +35,8 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Renovate opens its PRs as a bot; without this the action refuses to run.
+          allowed_bots: 'renovate'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'


### PR DESCRIPTION
The `claude-review` check has been failing on every external PR for two unrelated reasons, so the red X carried no signal.

**Renovate PRs** failed with:
```
Workflow initiated by non-human actor: renovate (type: Bot).
Add bot to allowed_bots list or use '*' to allow all bots.
```
Renovate branches live in this repo, so OIDC and secrets are available — only the bot gate was blocking. Adding `allowed_bots: 'renovate'` is enough. (The action strips a trailing `[bot]`, so `renovate` matches `renovate[bot]`.)

**Fork PRs** failed with:
```
Could not fetch an OIDC token. Did you remember to add `id-token: write`?
```
The permission *is* declared. GitHub downgrades the token to read-only for `pull_request` events from forks regardless, so this job can never succeed there. Skipping is the honest outcome; the alternative is `pull_request_target`, which would mean running fork-authored code with write credentials.

`claude.yml` is unaffected — `issue_comment` and friends always run in the base repo context.