### PR TITLE
fix(registry): generate fnox completions via usage

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -83,7 +83,6 @@ cue = "standard"
 dagger = "standard"
 doggo = "completions"
 dyff = "standard"
-fnox = "standard"
 gitleaks = "standard"
 golangci-lint = "standard"
 goreleaser = "standard"
@@ -118,6 +117,11 @@ cargo = { zsh = "rustup completions zsh cargo", bash = "rustup completions bash 
 
 # pipx uses argcomplete
 pipx = { zsh = "register-python-argcomplete --shell zsh pipx", bash = "register-python-argcomplete --shell bash pipx", fish = "register-python-argcomplete --shell fish pipx" }
+
+# fnox renders its completions with the `usage` CLI, which is a separate tool and
+# is not on PATH inside `mise x fnox`. The nested `mise x usage` supplies it, and
+# installs it on demand when it is missing.
+fnox = { zsh = "mise x usage -- fnox completion zsh", bash = "mise x usage -- fnox completion bash", fish = "mise x usage -- fnox completion fish" }
 
 prek = { zsh = "prek util generate-shell-completion zsh", bash = "prek util generate-shell-completion bash", fish = "prek util generate-shell-completion fish" }
 


### PR DESCRIPTION
`fnox` completions are broken on `main` today. Found while validating the open registry PRs — this one isn't from any of them.

```
$ mise x fnox -- fnox completion zsh
Error: fnox::io::error
  × I/O error: No such file or directory (os error 2)
```

Independent of cwd, and it still fails with an explicit valid `-c` config, so it isn't configuration. The cause is that `fnox` renders its completions by shelling out to the `usage` CLI, and `usage` is not on PATH inside `mise x fnox`. The `ENOENT` is fnox failing to exec it.

Nesting `mise x usage` supplies it:

```
$ mise x fnox -- mise x usage -- fnox completion zsh
#compdef fnox
# @generated by usage-cli from usage spec
```

Verified for all three shells (zsh 69 lines, bash 34, fish 23), and the full registry validator now passes **56/56** where it was 53/56 before. `docs/tools.md` regenerates byte-identical, so no doc churn.

**One tradeoff worth your call:** when `usage` isn't installed, `mise x usage` installs it on demand rather than failing. That means syncing completions can now pull in a tool the user didn't explicitly ask for. It only affects people who have `fnox` installed, and the alternative is the entry staying broken for everyone without `usage` in their config — but if you'd rather it degrade quietly instead, say so and I'll gate it.

Worth noting this is one instance of a general gap: a tool whose completion generation depends on a second binary being present. `hk` (proposed in #88) fails identically against `usage`, and `ipython`/`patool`/`ratarmount` (proposed in #108) fail the same way against `register-python-argcomplete`. The registry has no way to express that dependency, so each one needs a hack like this. Probably worth solving once.