### PR TITLE
ci: check docs/tools.md lists the same tools as registry.toml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,11 @@ jobs:
 
       - name: Test
         run: cargo test
+
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Check docs/tools.md matches registry.toml
+        run: python3 scripts/check-docs-sync.py

--- a/mise.toml
+++ b/mise.toml
@@ -40,6 +40,10 @@ description = "Generate tools documentation from registry"
 run = "uv run scripts/generate-tools-status.py > TOOLS.md"
 description = "Generate TOOLS.md with supported and pending tools"
 
+[tasks.check-docs]
+run = "uv run scripts/check-docs-sync.py"
+description = "Check docs/tools.md lists the same tools as registry.toml"
+
 [tasks.validate-registry]
 run = "uv run scripts/validate-registry.py --installed-only"
 description = "Validate registry entries against installed tools"

--- a/scripts/check-docs-sync.py
+++ b/scripts/check-docs-sync.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+# ABOUTME: Checks that docs/tools.md lists exactly the tools in registry.toml.
+# ABOUTME: Compares tool names only, so upstream description changes never fail it.
+"""
+Checks docs/tools.md is in sync with registry.toml.
+
+Usage: uv run scripts/check-docs-sync.py
+
+Compares the set of tool names in both files and exits non-zero if they
+differ. Descriptions and links come from `mise registry` and drift on their
+own schedule, so they are deliberately not compared -- regenerate with
+`mise run docs-tools` to fix a reported mismatch.
+"""
+
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+
+# Table rows look like "| tool | desc | ✓ | ✓ | ✓ |" where the tool cell is
+# either a bare name or a markdown link.
+ROW = re.compile(r"^\|\s*(?:\[([^\]]+)\]\([^)]*\)|([^|\s]+))\s*\|")
+
+
+def registry_tools() -> set[str]:
+    with open(ROOT / "registry.toml", "rb") as f:
+        return set(tomllib.load(f).get("tools", {}).keys())
+
+
+def documented_tools() -> set[str]:
+    tools = set()
+    for line in (ROOT / "docs" / "tools.md").read_text().splitlines():
+        if line.startswith("|-") or line.startswith("| Tool"):
+            continue
+        match = ROW.match(line)
+        if match:
+            tools.add(match.group(1) or match.group(2))
+    return tools
+
+
+def main() -> int:
+    in_registry = registry_tools()
+    in_docs = documented_tools()
+
+    undocumented = in_registry - in_docs
+    stale = in_docs - in_registry
+
+    if not undocumented and not stale:
+        print(f"docs/tools.md is in sync with registry.toml ({len(in_registry)} tools)")
+        return 0
+
+    if undocumented:
+        print("In registry.toml but missing from docs/tools.md:")
+        for tool in sorted(undocumented):
+            print(f"  + {tool}")
+    if stale:
+        print("In docs/tools.md but no longer in registry.toml:")
+        for tool in sorted(stale):
+            print(f"  - {tool}")
+
+    print("\nRegenerate with: mise run docs-tools")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
`docs/tools.md` is generated by `mise run docs-tools` but committed to the repo, and none of the open registry PRs regenerate it. So every one of them silently staleens the published tool list at mise-completions.alltuner.com.

Demonstrated by simulating #112 landing as-is:

```
$ uv run scripts/check-docs-sync.py
In registry.toml but missing from docs/tools.md:
  + clusterctl
  + cmctl

Regenerate with: mise run docs-tools
```

**Names only, deliberately.** The obvious implementation — regenerate and diff the whole file — would be flaky here. `generate-tools-docs.py` shells out to `mise registry --json` for descriptions and GitHub links, so an upstream description edit would fail CI on an unrelated PR, and it'd need `mise` installed in the workflow. Comparing the set of tool names catches the actual failure mode (a tool added to the registry but not the docs) while being deterministic and needing nothing but stdlib `python3`.

Runs as its own `docs` job so it doesn't wait on the Rust toolchain, and is available locally as `mise run check-docs`.

Verified it passes on a clean tree and fails on the simulated drift above.

Worth noting the related thing I did **not** touch: `scripts/generate-registry.py` keeps a `TOOL_PATTERNS` dict that duplicates `registry.toml`, and it's only ever consulted for tools *missing* from the registry — so every entry that's also in `registry.toml` is dead code, and the updates #113 and #121 make to that file are no-ops. Pruning it is a judgement call about what that dict is for, so I left it to you.