### PR TITLE
feat(registry): add requires for tools needing a helper binary

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -116,3 +116,16 @@ If a tool you use isn't listed:
 2. Add an entry to `registry.toml` using an existing pattern or explicit commands
 3. Test with `uv run scripts/validate-registry.py --installed-only`
 4. Submit a PR
+
+### Tools that need another binary
+
+Some tools shell out to a second binary to render completions, and fail
+when it is missing. `fnox`, for example, renders through `usage`. Name it
+with `requires` and it joins the same `mise x` invocation:
+
+```toml
+fnox = { requires = "usage", zsh = "fnox completion zsh" }
+```
+
+`requires` works on patterns too, when every tool sharing the pattern
+needs the same helper.

--- a/registry.toml
+++ b/registry.toml
@@ -128,10 +128,9 @@ cargo = { zsh = "rustup completions zsh cargo", bash = "rustup completions bash 
 # pipx uses argcomplete
 pipx = { zsh = "register-python-argcomplete --shell zsh pipx", bash = "register-python-argcomplete --shell bash pipx", fish = "register-python-argcomplete --shell fish pipx" }
 
-# fnox renders its completions with the `usage` CLI, which is a separate tool and
-# is not on PATH inside `mise x fnox`. The nested `mise x usage` supplies it, and
-# installs it on demand when it is missing.
-fnox = { zsh = "mise x usage -- fnox completion zsh", bash = "mise x usage -- fnox completion bash", fish = "mise x usage -- fnox completion fish" }
+# fnox renders its completions with the `usage` CLI, which is not on PATH inside
+# `mise x fnox` on its own.
+fnox = { requires = "usage", zsh = "fnox completion zsh", bash = "fnox completion bash", fish = "fnox completion fish" }
 
 prek = { zsh = "prek util generate-shell-completion zsh", bash = "prek util generate-shell-completion bash", fish = "prek util generate-shell-completion fish" }
 

--- a/scripts/generate-tools-docs.py
+++ b/scripts/generate-tools-docs.py
@@ -110,6 +110,19 @@ def main():
     print("2. Add an entry to `registry.toml` using an existing pattern or explicit commands")
     print("3. Test with `uv run scripts/validate-registry.py --installed-only`")
     print("4. Submit a PR")
+    print()
+    print("### Tools that need another binary")
+    print()
+    print("Some tools shell out to a second binary to render completions, and fail")
+    print("when it is missing. `fnox`, for example, renders through `usage`. Name it")
+    print("with `requires` and it joins the same `mise x` invocation:")
+    print()
+    print("```toml")
+    print('fnox = { requires = "usage", zsh = "fnox completion zsh" }')
+    print("```")
+    print()
+    print("`requires` works on patterns too, when every tool sharing the pattern")
+    print("needs the same helper.")
 
 
 if __name__ == "__main__":

--- a/scripts/validate-registry.py
+++ b/scripts/validate-registry.py
@@ -67,9 +67,12 @@ def load_registry() -> dict[str, dict[str, str]]:
     return expanded
 
 
-def test_completion(tool: str, shell: str, command: str) -> tuple[bool, str]:
+def test_completion(
+    tool: str, shell: str, command: str, requires: str | None = None
+) -> tuple[bool, str]:
     """Test a completion command. Returns (success, error_message)."""
-    wrapped = f"mise x {tool} -- {command}"
+    tools = f"{tool} {requires}" if requires else tool
+    wrapped = f"mise x {tools} -- {command}"
     result = subprocess.run(
         ["sh", "-c", wrapped],
         capture_output=True,
@@ -103,6 +106,7 @@ def main():
             continue
 
         completions = registry[tool]
+        requires = completions.get("requires")
         results[tool] = {}
 
         print(f"[{i}/{total}] {tool}...", end=" ", flush=True)
@@ -114,7 +118,7 @@ def main():
 
             command = completions[shell]
             try:
-                ok, err = test_completion(tool, shell, command)
+                ok, err = test_completion(tool, shell, command, requires)
                 results[tool][shell] = (ok, err)
                 if not ok:
                     tool_ok = False

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -39,6 +39,9 @@ pub struct ToolCompletions {
     pub zsh: Option<String>,
     pub bash: Option<String>,
     pub fish: Option<String>,
+    /// Another mise tool that must be on PATH for the command to work, because
+    /// the tool shells out to it to render completions (e.g. fnox needs `usage`).
+    pub requires: Option<String>,
 }
 
 impl ToolCompletions {
@@ -57,6 +60,7 @@ impl ToolCompletions {
             zsh: self.zsh.as_ref().map(|s| s.replace("{}", tool_name)),
             bash: self.bash.as_ref().map(|s| s.replace("{}", tool_name)),
             fish: self.fish.as_ref().map(|s| s.replace("{}", tool_name)),
+            requires: self.requires.clone(),
         }
     }
 }
@@ -158,6 +162,29 @@ mod tests {
         assert_eq!(xh.zsh.as_deref(), Some("xh --generate=complete-zsh"));
         assert_eq!(xh.bash.as_deref(), Some("xh --generate=complete-bash"));
         assert_eq!(xh.fish.as_deref(), Some("xh --generate=complete-fish"));
+    }
+
+    #[test]
+    fn test_fnox_requires_usage() {
+        // fnox renders completions by shelling out to the `usage` CLI, which is not
+        // on PATH inside `mise x fnox`. The command itself stays plain; `requires`
+        // is what puts usage there.
+        let registry = load_registry().expect("Failed to load registry");
+        let fnox = registry
+            .tools
+            .get("fnox")
+            .expect("fnox should be in registry");
+        assert_eq!(fnox.requires.as_deref(), Some("usage"));
+        assert_eq!(fnox.zsh.as_deref(), Some("fnox completion zsh"));
+        assert_eq!(fnox.bash.as_deref(), Some("fnox completion bash"));
+        assert_eq!(fnox.fish.as_deref(), Some("fnox completion fish"));
+    }
+
+    #[test]
+    fn test_requires_defaults_to_none() {
+        let registry = load_registry().expect("Failed to load registry");
+        let yq = registry.tools.get("yq").expect("yq should be in registry");
+        assert_eq!(yq.requires, None);
     }
 
     #[test]

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -237,10 +237,22 @@ fn parse_installed_tools_json(
 }
 
 /// Generate completion for a single tool and shell
+/// Build the `mise x` invocation for a completion command.
+///
+/// A tool listing `requires` needs a second binary on PATH to render its
+/// completions. Naming it here puts both tools in the same environment.
+fn wrap_command(tool_id: &str, requires: Option<&str>, command: &str) -> String {
+    match requires {
+        Some(required) => format!("mise x {tool_id} {required} -- {command}"),
+        None => format!("mise x {tool_id} -- {command}"),
+    }
+}
+
 fn generate_completion(
     tool_id: &str,   // Original ID with backend prefix (for mise x)
     tool_name: &str, // Stripped name (for filename)
     command: &str,
+    requires: Option<&str>,
     shell: &str,
     output_dir: &PathBuf,
 ) -> Result<(), Error> {
@@ -248,7 +260,7 @@ fn generate_completion(
     std::fs::create_dir_all(output_dir).map_err(|e| Error::CreateDir(output_dir.clone(), e))?;
 
     // Run the completion command wrapped with mise to ensure the tool is available
-    let wrapped_command = format!("mise x {tool_id} -- {command}");
+    let wrapped_command = wrap_command(tool_id, requires, command);
     let output = Command::new("sh")
         .args(["-c", &wrapped_command])
         .output()
@@ -328,9 +340,14 @@ pub fn sync_completions(
                 if let Some(cmd) = completions.get(shell) {
                     // Use the original tool ID (with backend prefix) for mise x
                     // and the stripped name for the filename
-                    if let Err(e) =
-                        generate_completion(original_id, short_name, cmd, shell, &output_dir)
-                    {
+                    if let Err(e) = generate_completion(
+                        original_id,
+                        short_name,
+                        cmd,
+                        completions.requires.as_deref(),
+                        shell,
+                        &output_dir,
+                    ) {
                         eprintln!("  {short_name}: {e}");
                     }
                 }
@@ -390,6 +407,32 @@ mod tests {
             base_dir: PathBuf::from(base),
             shell_overrides: HashMap::new(),
         }
+    }
+
+    #[test]
+    fn test_wrap_command_without_requires() {
+        assert_eq!(
+            wrap_command("yq", None, "yq completion zsh"),
+            "mise x yq -- yq completion zsh"
+        );
+    }
+
+    #[test]
+    fn test_wrap_command_with_requires() {
+        // The helper tool joins the same `mise x` invocation, so it lands on PATH
+        // for the command without a nested `mise x`.
+        assert_eq!(
+            wrap_command("fnox", Some("usage"), "fnox completion zsh"),
+            "mise x fnox usage -- fnox completion zsh"
+        );
+    }
+
+    #[test]
+    fn test_wrap_command_preserves_backend_prefix() {
+        assert_eq!(
+            wrap_command("pipx:ipython", Some("pipx:argcomplete"), "ipython x"),
+            "mise x pipx:ipython pipx:argcomplete -- ipython x"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes the gap behind three separate PRs.

Some tools render completions by shelling out to a second binary, and fail when it isn't on PATH inside `mise x <tool>`. `fnox` and `hk` (#88) go through `usage`; `ipython`, `patool` and `ratarmount` (#108) need `register-python-argcomplete`. The registry had no way to say so, so #124 worked around it by nesting a second `mise x` **inside** the command string:

```toml
fnox = { zsh = "mise x usage -- fnox completion zsh", ... }
```

An entry can now name the helper directly:

```toml
fnox = { requires = "usage", zsh = "fnox completion zsh", ... }
```

and `sync` emits `mise x fnox usage -- fnox completion zsh` — one invocation, two tools, no nesting.

`requires` lives on `ToolCompletions`, so **patterns can carry it too**. That matters for #108, where one `argcomplete` pattern is shared by four tools that all need the same helper — it can be declared once on the pattern rather than repeated per tool.

## Verified

Built the release binary and ran it with `usage` **not** installed — the exact case that was broken:

```
$ ./target/release/misecompsync -s zsh fnox
  fnox -> _fnox
$ head -2 .../zsh/_fnox
#compdef fnox
# @generated by usage-cli from usage spec
```

`validate-registry.py` learned the same wrapping so validation matches real behaviour: **62/62 passing**. 27 unit tests, clippy and fmt clean. `requires` is documented in the generated "Adding New Tools" section.

## Notes

- The docs generator reads `zsh`/`bash`/`fish` explicitly, so `requires` is inert there — no shell-support columns change.
- Deliberately shaped to compose with #119 rather than fight it: that PR flattens `ToolCompletions` into a new `ExplicitToolEntry` alongside `provided_by`, and a field living inside `ToolCompletions` survives that flatten. The two are complementary — `provided_by` means "generate me when *that* is installed", `requires` means "put *that* on PATH while generating me".
- This does **not** change the auto-install behaviour: `mise x` still installs a missing helper on demand, silently, because `sync.rs` drops stderr on success. Worth fixing separately.