### PR TITLE
fix(sync): report stderr from commands that succeed

### DIFF
--- a/src/sync.rs
+++ b/src/sync.rs
@@ -248,6 +248,22 @@ fn wrap_command(tool_id: &str, requires: Option<&str>, command: &str) -> String 
     }
 }
 
+/// Lines to report for a command that succeeded but still wrote to stderr.
+///
+/// mise installs a missing `requires` tool on demand and reports it here, so
+/// discarding stderr on success hides software being installed.
+fn diagnostics(tool_name: &str, stderr: &[u8]) -> Vec<String> {
+    let stderr = String::from_utf8_lossy(stderr);
+    if stderr.trim().is_empty() {
+        return Vec::new();
+    }
+    stderr
+        .trim_end()
+        .lines()
+        .map(|line| format!("  {tool_name}: {line}"))
+        .collect()
+}
+
 fn generate_completion(
     tool_id: &str,   // Original ID with backend prefix (for mise x)
     tool_name: &str, // Stripped name (for filename)
@@ -269,6 +285,10 @@ fn generate_completion(
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         return Err(Error::Generate(tool_name.to_string(), stderr.to_string()));
+    }
+
+    for line in diagnostics(tool_name, &output.stderr) {
+        eprintln!("{line}");
     }
 
     // Write the completion file using the stripped name (not the original ID)
@@ -407,6 +427,34 @@ mod tests {
             base_dir: PathBuf::from(base),
             shell_overrides: HashMap::new(),
         }
+    }
+
+    #[test]
+    fn test_diagnostics_empty_when_nothing_written() {
+        assert!(diagnostics("fnox", b"").is_empty());
+        assert!(diagnostics("fnox", b"  \n\t \n").is_empty());
+    }
+
+    #[test]
+    fn test_diagnostics_attribute_each_line_to_the_tool() {
+        assert_eq!(
+            diagnostics(
+                "fnox",
+                b"mise usage@4.0.0 install\nmise usage@4.0.0 download\n"
+            ),
+            vec![
+                "  fnox: mise usage@4.0.0 install",
+                "  fnox: mise usage@4.0.0 download",
+            ]
+        );
+    }
+
+    #[test]
+    fn test_diagnostics_handle_invalid_utf8() {
+        assert_eq!(
+            diagnostics("fnox", b"warn: \xff\xfe"),
+            vec!["  fnox: warn: ��"]
+        );
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #126. A completion command that exits zero can still write to stderr, and `generate_completion` threw that away — it only read stderr on failure.

That mattered once `requires` landed: `mise x` installs a missing helper tool on demand, reports it on stderr, and succeeds. So syncing completions could install software with no indication at all. It also silently swallowed any warning a tool emitted while still producing valid output.

Before, `usage` not installed:

```
$ misecompsync -s zsh fnox
  fnox -> _fnox
```

After — same command, same state:

```
STDOUT:
  fnox -> _fnox

STDERR:
  fnox: mise usage@4.0.0    [1/3] install
  fnox: mise usage@4.0.0    [1/3] download usage-universal-apple-darwin.tar.gz
  fnox: mise usage@4.0.0    [2/3] checksum usage-universal-apple-darwin.tar.gz
  fnox: mise usage@4.0.0    [3/3] extract usage-universal-apple-darwin.tar.gz
  fnox: mise usage@4.0.0  ✓ installed
```

Diagnostics go to **stderr**, so the stdout progress listing stays pipeable. Each line is prefixed with the tool it came from, since several tools are processed per run and unattributed output would be guesswork.

Extracted as `diagnostics()` so the formatting is unit-testable rather than buried in an `eprintln!`. Covers the empty, whitespace-only, multi-line and invalid-UTF-8 cases. 30 tests, clippy and fmt clean.

Note for #114: this touches `generate_completion` right where that PR adds its empty-output guard, so expect a small conflict — both changes sit just after the success check and are compatible.