### PR TITLE
feat(registry): merge a user registry over the built-in one

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,34 @@ If you want to only generate completions for newly installed or updated tools, y
 postinstall = "misecompsync --new-only"
 ```
 
+## Custom Registry
+
+The list of supported tools is built into the binary, but you don't have to wait
+for a release (or send a PR) to add your own. Drop a `registry.toml` at
+`$XDG_DATA_HOME/mise-completions-sync/registry.toml`, or next to the
+`misecompsync` executable, and it is laid on top of the built-in registry:
+
+```toml
+schema_version = 1
+
+[tools]
+# a tool the built-in registry doesn't cover
+graphite-cli = { zsh = "gt completion zsh", bash = "gt completion bash" }
+
+# built-in patterns are available to your own entries
+mytool = "standard"
+
+# override a built-in entry
+yq = { zsh = "yq shell-completion zsh" }
+```
+
+Your entries are merged with the built-in ones rather than replacing them, so a
+short file like the above adds `graphite-cli` and `mytool` and changes `yq`,
+while every other tool keeps working. `schema_version` is required.
+
+If an entry turns out to be generally useful, [open a PR](https://github.com/alltuner/mise-completions-sync/blob/main/registry.toml)
+so everyone gets it.
+
 ## Updating
 
 ```bash

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -9,24 +9,70 @@ mise-completions-sync follows a simple process to generate shell completions:
 
 ## Registry
 
-The registry (`registry.toml`) contains patterns for generating completions. Each entry specifies:
-
-- The tool name (matching mise's tool name)
-- A format pattern for the completion command
-- Which shells are supported
-
-Example entry:
+The registry (`registry.toml`) maps each tool to the command that prints its
+completion script. Most tools share a handful of conventions, so those live in
+`[patterns]`, where `{}` stands in for the tool name:
 
 ```toml
-[tools.kubectl]
-format = "{bin} completion {shell}"
-shells = ["zsh", "bash", "fish"]
+[patterns]
+standard = { zsh = "{} completion zsh", bash = "{} completion bash", fish = "{} completion fish" }
+
+[tools]
+kubectl = "standard"
 ```
 
-The format pattern supports these placeholders:
+A tool whose command doesn't fit a pattern spells it out per shell. Omitting a
+shell means the tool doesn't support it:
 
-- `{bin}` - The tool's binary path
-- `{shell}` - The target shell (zsh, bash, fish)
+```toml
+[tools]
+npm = { zsh = "npm completion", bash = "npm completion" }
+```
+
+Two optional fields cover tools that need more than a command:
+
+- `requires` names another mise tool that must be on PATH while generating,
+  for tools that shell out to a helper. `fnox` renders through `usage`:
+
+  ```toml
+  fnox = { requires = "usage", zsh = "fnox completion zsh" }
+  ```
+
+- `provided_by` marks a binary that arrives as part of another mise tool rather
+  than being one itself, like `uvx` from `uv`. Its completions are generated
+  whenever the provider is installed.
+
+Commands run inside `mise x <tool> -- …`, so they resolve against the version
+mise has installed rather than whatever is on your PATH.
+
+## Custom Registry
+
+The built-in registry is embedded in the binary, but you can extend it. If a
+`registry.toml` exists next to the executable, or at
+`$XDG_DATA_HOME/mise-completions-sync/registry.toml`, it is laid **on top of**
+the built-in one rather than replacing it.
+
+```toml
+schema_version = 1
+
+[tools]
+# a tool the built-in registry doesn't know about
+graphite-cli = { zsh = "gt completion zsh", bash = "gt completion bash" }
+
+# built-in patterns are available to your entries
+mytool = "standard"
+
+# and you can override a built-in entry
+yq = { zsh = "yq shell-completion zsh" }
+```
+
+Merging happens before patterns are resolved, so your entries can use the
+built-in patterns, and redefining a pattern reaches every tool that references
+it. `schema_version` is required. Entries can be added or overridden; there is
+no way to remove a built-in entry.
+
+The executable's directory takes precedence over the XDG location, and only one
+user registry applies.
 
 ## Output Locations
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -91,6 +91,31 @@ export MISE_COMPLETIONS_SYNC_FISH_DIR="$XDG_DATA_HOME/fish/vendor_completions.d"
 
 Note: Target directories will be created if they don't already exist. Don't forget to update your shell setup above.
 
+## Custom Registry
+
+The supported tool list is built into the binary, but you can extend it without
+waiting for a release. Put a `registry.toml` at
+`$XDG_DATA_HOME/mise-completions-sync/registry.toml`, or next to the
+`misecompsync` executable, and it is laid on top of the built-in registry:
+
+```toml
+schema_version = 1
+
+[tools]
+# a tool the built-in registry doesn't cover
+graphite-cli = { zsh = "gt completion zsh", bash = "gt completion bash" }
+
+# built-in patterns are available to your own entries
+mytool = "standard"
+
+# override a built-in entry
+yq = { zsh = "yq shell-completion zsh" }
+```
+
+Entries are merged with the built-in ones rather than replacing them, so the
+tools you don't mention keep working. `schema_version` is required. See
+[How It Works](how-it-works.md) for the full registry format.
+
 ## Updating
 
 ### Homebrew

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -78,40 +78,41 @@ impl ToolCompletions {
     }
 }
 
-/// Try to load registry from external file, with fallback to embedded
-fn get_registry_content() -> Result<(String, Option<PathBuf>), Error> {
-    // Check for registry.toml next to the executable (allows user customization)
+/// Find a user-provided registry to lay over the built-in one, if there is one.
+///
+/// The executable's own directory wins over the XDG one; only a single user
+/// registry applies.
+fn user_registry_content() -> Result<Option<(String, PathBuf)>, Error> {
+    let mut candidates = Vec::new();
+
     if let Ok(exe_path) = std::env::current_exe() {
-        let alongside = exe_path.parent().unwrap().join("registry.toml");
-        if alongside.exists() {
-            let content = std::fs::read_to_string(&alongside)
-                .map_err(|e| Error::RegistryRead(alongside.clone(), e))?;
-            return Ok((content, Some(alongside)));
-        }
+        candidates.push(exe_path.parent().unwrap().join("registry.toml"));
     }
-
-    // Check XDG data directory for user-provided registry
     if let Some(data_dir) = dirs::data_dir() {
-        let user_registry = data_dir.join("mise-completions-sync").join("registry.toml");
-        if user_registry.exists() {
-            let content = std::fs::read_to_string(&user_registry)
-                .map_err(|e| Error::RegistryRead(user_registry.clone(), e))?;
-            return Ok((content, Some(user_registry)));
+        candidates.push(data_dir.join("mise-completions-sync").join("registry.toml"));
+    }
+
+    for path in candidates {
+        if path.exists() {
+            let content =
+                std::fs::read_to_string(&path).map_err(|e| Error::RegistryRead(path.clone(), e))?;
+            return Ok(Some((content, path)));
         }
     }
 
-    // Use embedded registry
-    Ok((EMBEDDED_REGISTRY.to_string(), None))
+    Ok(None)
 }
 
 pub fn load_registry() -> Result<Registry, Error> {
-    let (content, path) = get_registry_content()?;
-    let path_for_error = path.clone().unwrap_or_else(|| PathBuf::from("<embedded>"));
-
-    parse_registry(&content, path_for_error)
+    let user = user_registry_content()?;
+    build_registry(
+        EMBEDDED_REGISTRY,
+        user.as_ref()
+            .map(|(content, path)| (content.as_str(), path.clone())),
+    )
 }
 
-fn parse_registry(content: &str, path_for_error: PathBuf) -> Result<Registry, Error> {
+fn parse_raw(content: &str, path_for_error: PathBuf) -> Result<RawRegistry, Error> {
     let raw: RawRegistry =
         toml::from_str(content).map_err(|e| Error::RegistryParse(path_for_error.clone(), e))?;
 
@@ -127,6 +128,26 @@ fn parse_registry(content: &str, path_for_error: PathBuf) -> Result<Registry, Er
         Some(_) => {}
     }
 
+    Ok(raw)
+}
+
+/// Parse the built-in registry and lay a user registry over it.
+///
+/// Merging happens before patterns are resolved, so a user entry can reference
+/// a built-in pattern, and redefining a pattern reaches the tools that use it.
+fn build_registry(embedded: &str, user: Option<(&str, PathBuf)>) -> Result<Registry, Error> {
+    let mut raw = parse_raw(embedded, PathBuf::from("<embedded>"))?;
+
+    if let Some((content, path)) = user {
+        let overlay = parse_raw(content, path)?;
+        raw.patterns.extend(overlay.patterns);
+        raw.tools.extend(overlay.tools);
+    }
+
+    expand(raw)
+}
+
+fn expand(raw: RawRegistry) -> Result<Registry, Error> {
     let mut tools = HashMap::new();
 
     for (tool_name, entry) in raw.tools {
@@ -247,9 +268,123 @@ mod tests {
         );
     }
 
+    const BASE: &str = r#"
+schema_version = 1
+
+[patterns]
+standard = { zsh = "{} completion zsh", bash = "{} completion bash" }
+
+[tools]
+builtin = "standard"
+override_me = { zsh = "original zsh" }
+"#;
+
+    fn overlaid(user: &str) -> Registry {
+        build_registry(BASE, Some((user, PathBuf::from("<user>"))))
+            .expect("Failed to build registry")
+    }
+
+    #[test]
+    fn test_user_registry_adds_a_tool_without_losing_builtins() {
+        // The whole point: a three-line user file must not switch off the other
+        // entries, which is what replacing the registry used to do.
+        let registry = overlaid(
+            r#"
+schema_version = 1
+
+[tools]
+graphite-cli = { zsh = "gt completion zsh" }
+"#,
+        );
+
+        assert_eq!(
+            registry.tools["graphite-cli"].completions.zsh.as_deref(),
+            Some("gt completion zsh")
+        );
+        assert_eq!(
+            registry.tools["builtin"].completions.zsh.as_deref(),
+            Some("builtin completion zsh")
+        );
+    }
+
+    #[test]
+    fn test_user_entry_overrides_builtin() {
+        let registry = overlaid(
+            r#"
+schema_version = 1
+
+[tools]
+override_me = { zsh = "user zsh" }
+"#,
+        );
+
+        assert_eq!(
+            registry.tools["override_me"].completions.zsh.as_deref(),
+            Some("user zsh")
+        );
+    }
+
+    #[test]
+    fn test_user_entry_can_reference_a_builtin_pattern() {
+        // Patterns are resolved after merging, so a user never has to redeclare
+        // `standard` just to use it.
+        let registry = overlaid(
+            r#"
+schema_version = 1
+
+[tools]
+mytool = "standard"
+"#,
+        );
+
+        assert_eq!(
+            registry.tools["mytool"].completions.zsh.as_deref(),
+            Some("mytool completion zsh")
+        );
+    }
+
+    #[test]
+    fn test_user_can_redefine_a_builtin_pattern() {
+        let registry = overlaid(
+            r#"
+schema_version = 1
+
+[patterns]
+standard = { zsh = "{} --fixed-completions zsh" }
+"#,
+        );
+
+        assert_eq!(
+            registry.tools["builtin"].completions.zsh.as_deref(),
+            Some("builtin --fixed-completions zsh")
+        );
+    }
+
+    #[test]
+    fn test_no_user_registry_leaves_builtins_untouched() {
+        let registry = build_registry(BASE, None).expect("Failed to build registry");
+
+        assert_eq!(registry.tools.len(), 2);
+        assert_eq!(
+            registry.tools["override_me"].completions.zsh.as_deref(),
+            Some("original zsh")
+        );
+    }
+
+    #[test]
+    fn test_user_registry_still_needs_a_schema_version() {
+        let err = build_registry(
+            BASE,
+            Some(("[tools]\nfoo = \"standard\"\n", PathBuf::from("<user>"))),
+        )
+        .expect_err("a user registry without schema_version should be rejected");
+
+        assert!(matches!(err, Error::MissingSchemaVersion));
+    }
+
     #[test]
     fn test_explicit_entry_with_provider() {
-        let registry = parse_registry(
+        let registry = build_registry(
             r#"
 schema_version = 1
 
@@ -260,7 +395,7 @@ standard = { zsh = "{} completion zsh" }
 parent = "standard"
 child = { provided_by = "parent", zsh = "child completion zsh", bash = "child completion bash" }
 "#,
-            PathBuf::from("<test>"),
+            None,
         )
         .expect("Failed to parse registry");
 


### PR DESCRIPTION
Closes #99.

A user `registry.toml` — next to the executable, or at `$XDG_DATA_HOME/mise-completions-sync/registry.toml` — already existed, but `get_registry_content` **returned on the first match**, so it *replaced* the built-in registry rather than extending it. Adding one tool locally meant copying all 99 entries and maintaining them forever. The mechanism was also documented nowhere, which is the main reason changing its semantics is safe: there is no way anyone was relying on replacement deliberately.

Now the user file is laid on top:

```toml
schema_version = 1

[tools]
graphite-cli = { zsh = "gt completion zsh" }   # new tool
mytool = "standard"                            # built-in pattern
yq = { zsh = "yq shell-completion zsh" }       # override a built-in
```

## The bit that needed care

The obvious implementation — parse the user file and `extend` the tool map — doesn't work. Patterns are resolved *inside* the parse, against a single file, so `mytool = "standard"` would fail with `UnknownPattern` because `standard` lives in the embedded registry the user can't see.

So `parse_registry` is split into `parse_raw` and `expand`, and the merge happens **between** them, on the raw maps. That's what makes both of these work: user entries can reference built-in patterns, and redefining a pattern reaches every tool that uses it.

## Verified

Against the real binary, using an actual user registry file (not just unit tests):

```
$ misecompsync list | wc -l          # baseline
99
$ cat target/release/registry.toml
graphite-cli = { zsh = "gt completion zsh" }
mytool = "standard"
yq = { zsh = "yq shell-completion zsh" }
$ misecompsync list | wc -l          # +2, yq overridden not added
101
$ misecompsync -s zsh yq             # override actually used
  yq -> _yq
```

Built-ins survive, and removing the file returns to 99. 55 tests, clippy and fmt clean.

## Decisions worth flagging

- **`schema_version` stays required** in the user file. It's the guard that makes format changes safe, but it is a papercut on a three-line personal file — happy to relax it.
- **Two layers, not three.** The exe-adjacent file still beats the XDG one; only one user registry applies. Layering both felt like YAGNI.
- **No way to remove a built-in entry.** A merge can add and override but not delete. If someone wants to switch off an entry we'd need something like `tool = false`; left out until asked for.

## Docs

The feature had none, so: a Custom Registry section in the README and `docs/index.md`, and a fuller one in `docs/how-it-works.md`.

While there I corrected that page's Registry section, which documented a schema the code has never had — `[tools.kubectl] format = "{bin} completion {shell}"` with a `shells` array. It now describes the real `[patterns]`/`{}` format, plus `requires` and `provided_by`.