### PR TITLE
feat(registry): add uvx completions

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -5,7 +5,7 @@ Use this to identify tools that could be added to mise-completions-sync.
 
 ## Supported Tools
 
-Currently **92 tools** have completion support.
+Currently **100 tools** have completion support.
 
 See [docs/tools.md](docs/tools.md) for the full list with shell support details.
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -97,6 +97,7 @@ The following tools have shell completion support in mise-completions-sync.
 | [ty](https://github.com/astral-sh/ty) | An extremely fast Python type checker and langu... | ✓ | ✓ | ✓ |
 | [usage](https://github.com/jdx/usage) | A specification for CLIs | ✓ | ✓ | ✓ |
 | [uv](https://github.com/astral-sh/uv) | An extremely fast Python package installer and ... | ✓ | ✓ | ✓ |
+| uvx |  | ✓ | ✓ | ✓ |
 | [velero](https://github.com/vmware-tanzu/velero) | Backup and migrate Kubernetes applications and ... | ✓ | ✓ | ✓ |
 | vercel | Build and deploy on the Vercel cloud | ✓ | ✓ |  |
 | [watchexec](https://github.com/watchexec/watchexec) | Executes commands in response to file modificat... | ✓ | ✓ | ✓ |
@@ -104,7 +105,7 @@ The following tools have shell completion support in mise-completions-sync.
 | [yq](https://github.com/mikefarah/yq) | yq is a portable command-line YAML processor | ✓ | ✓ | ✓ |
 | [zellij](https://github.com/zellij-org/zellij) | A terminal workspace with batteries included | ✓ | ✓ | ✓ |
 
-**Total: 99 tools**
+**Total: 100 tools**
 
 ## Shell Support Legend
 

--- a/registry.toml
+++ b/registry.toml
@@ -51,6 +51,7 @@ rustup = "completions"
 deno = "completions"
 starship = "completions"
 uv = "generate_shell"
+uvx = { provided_by = "uv", zsh = "uvx --generate-shell-completion zsh", bash = "uvx --generate-shell-completion bash", fish = "uvx --generate-shell-completion fish" }
 ruff = "generate_shell"
 ty = "generate_shell"
 mdbook = "generate_shell"

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -248,6 +248,29 @@ mod tests {
     }
 
     #[test]
+    fn test_uvx_in_registry() {
+        let registry = load_registry().expect("Failed to load registry");
+        let uvx = registry
+            .tools
+            .get("uvx")
+            .expect("uvx should be in registry");
+
+        assert_eq!(uvx.provided_by.as_deref(), Some("uv"));
+        assert_eq!(
+            uvx.completions.zsh.as_deref(),
+            Some("uvx --generate-shell-completion zsh")
+        );
+        assert_eq!(
+            uvx.completions.bash.as_deref(),
+            Some("uvx --generate-shell-completion bash")
+        );
+        assert_eq!(
+            uvx.completions.fish.as_deref(),
+            Some("uvx --generate-shell-completion fish")
+        );
+    }
+
+    #[test]
     fn test_explicit_entry_with_provider() {
         let registry = parse_registry(
             r#"


### PR DESCRIPTION
## Summary

- register `uvx` as a companion binary provided by `uv`
- generate zsh, bash, and fish completions with `uvx --generate-shell-completion`
- add embedded-registry coverage and update generated tool inventories

This is the focused registry follow-up enabled by #119.

Refs #76

## Tests

- `cargo fmt --check`
- `python3 scripts/check-docs-sync.py` — 100 tools in sync
- `python3 scripts/validate-registry.py --installed-only` — `uv` and `uvx` passed zsh, bash, and fish; the full local run still reports the pre-existing `gitui gen-completions` failure
- direct `mise x uv -- uvx --generate-shell-completion <shell>` checks for zsh, bash, and fish produced non-empty completion scripts
- GitHub Actions `CI/check`, docs sync, and PR title checks passed
