### PR TITLE
ci: publish to crates.io via OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,12 +27,19 @@ jobs:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created }}
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v7
         with:
           ref: ${{ needs.release-please.outputs.tag_name }}
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo publish --token ${{ secrets.CRATES_IO_TOKEN }}
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+      - run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
   build-binaries:
     needs: release-please


### PR DESCRIPTION
Replaces the long-lived `CRATES_IO_TOKEN` secret with a short-lived token minted per run by `rust-lang/crates-io-auth-action@v1`, matching how `alltuner/vacant` publishes.

The `publish-crate` job gets its own `permissions` block (`id-token: write` for the OIDC exchange, `contents: read`), which narrows it from the workflow-level `contents: write` / `pull-requests: write` it was inheriting.

**Requires the trusted publisher to already be registered on crates.io** for the `mise-completions-sync` crate (owner `alltuner`, repo `mise-completions-sync`, workflow `release.yml`) — it is. Without it the OIDC exchange 404s and the release fails at publish.

Prompted by the expiry notice for the token backing `CRATES_IO_TOKEN`: it expires 2026-07-31T22:15:29Z. After the first release publishes green on this, delete the `CRATES_IO_TOKEN` repo secret and revoke the token on crates.io.

`actionlint` is clean. There's no way to exercise this before merge — the publish path only runs on a real release from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Si9yXHSXkoLxiHLXPMRFbJ