### PR TITLE
ci: audit the whole registry on a schedule

### DIFF
--- a/.github/workflows/registry-audit.yml
+++ b/.github/workflows/registry-audit.yml
@@ -1,0 +1,59 @@
+name: Registry Audit
+
+# Installs every tool in the registry and checks its completion command still
+# works. CI only ever validates tools that happen to be installed on the runner,
+# so an entry that is wrong for everyone otherwise goes unnoticed indefinitely.
+
+on:
+  schedule:
+    - cron: '0 4 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: jdx/mise-action@v4
+        with:
+          # Only uv is needed to run the script; the audit installs the rest
+          # itself, and caching those would both bloat the cache and let a stale
+          # install mask a broken entry.
+          install_args: uv
+          cache: false
+
+      - name: Audit registry
+        id: audit
+        run: |
+          set -o pipefail
+          uv run scripts/validate-registry.py --install 2>&1 | tee audit.log
+
+      - name: Open or update tracking issue
+        if: failure() && steps.audit.conclusion == 'failure'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TITLE: 'Registry audit: broken completion commands'
+        run: |
+          {
+            echo "The scheduled registry audit installed each tool and found entries whose"
+            echo "completion command no longer works."
+            echo
+            echo "[Full run](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})"
+            echo
+            sed -n '/^## Broken entries/,$p' audit.log
+          } > issue.md
+
+          number=$(gh issue list --state open --search "$TITLE in:title" --json number,title \
+            --jq ".[] | select(.title == \"$TITLE\") | .number" | head -1)
+
+          if [ -n "$number" ]; then
+            gh issue comment "$number" --body-file issue.md
+          else
+            gh issue create --title "$TITLE" --body-file issue.md
+          fi

--- a/docs/development.md
+++ b/docs/development.md
@@ -29,6 +29,7 @@ The project uses mise tasks for common operations. Run `mise tasks` to see all a
 | `mise run install-hooks` | Install pre-commit hooks |
 | `mise run generate-registry` | Generate registry.toml from mise's registry |
 | `mise run validate-registry` | Validate registry entries against installed tools |
+| `mise run audit-registry` | Install every registry tool and verify it (slow) |
 | `mise run docs-tools` | Generate tools documentation from registry |
 
 ## Adding Tools to the Registry
@@ -42,17 +43,36 @@ If a tool you use isn't in the registry:
 
 ### Registry Entry Format
 
-```toml
-[tools.mytool]
-format = "{bin} completion {shell}"
-shells = ["zsh", "bash", "fish"]
-```
-
-Some tools use different subcommands or flags:
+Most tools follow one of the shared conventions in `[patterns]`, where `{}`
+stands in for the tool name:
 
 ```toml
-# Tool uses --shell flag
-[tools.othertool]
-format = "{bin} completions --shell {shell}"
-shells = ["zsh", "bash"]
+[tools]
+mytool = "standard"      # {} completion <shell>
 ```
+
+A tool that doesn't fit a pattern spells out each shell. Omitting a shell means
+the tool doesn't support it:
+
+```toml
+[tools]
+othertool = { zsh = "othertool completions --shell zsh", bash = "othertool completions --shell bash" }
+```
+
+Optional fields cover the awkward cases: `requires` names a helper binary the
+command needs on PATH, `provided_by` marks a binary that ships inside another
+mise tool, and `bundled` means the tool ships completion files rather than
+generating them (each shell's value is then the filename to look for). See
+[How It Works](how-it-works.md) for details.
+
+### Registry Audit
+
+`mise run validate-registry` only checks tools that happen to be installed on
+the machine running it, so an entry that is wrong for everyone still passes. The
+`Registry Audit` workflow runs weekly, installs every tool in the registry and
+verifies each command, and opens an issue when something is broken. Tools that
+won't install on the runner are reported separately — that says nothing about
+whether the entry is correct.
+
+Run it locally with `mise run audit-registry`. It installs every tool in the
+registry, so expect it to be slow and to leave a lot behind.

--- a/mise.toml
+++ b/mise.toml
@@ -44,6 +44,10 @@ description = "Generate TOOLS.md with supported and pending tools"
 run = "uv run scripts/check-docs-sync.py"
 description = "Check docs/tools.md lists the same tools as registry.toml"
 
+[tasks.audit-registry]
+run = "uv run scripts/validate-registry.py --install"
+description = "Install every registry tool and verify its completion command (slow)"
+
 [tasks.validate-registry]
 run = "uv run scripts/validate-registry.py --installed-only"
 description = "Validate registry entries against installed tools"

--- a/scripts/validate-registry.py
+++ b/scripts/validate-registry.py
@@ -116,29 +116,61 @@ def test_completion(
     return False, error
 
 
+def install_tool(target: str) -> tuple[bool, str]:
+    """Install a tool with mise. Returns (installed, reason_if_not)."""
+    try:
+        result = subprocess.run(
+            ["mise", "install", f"{target}@latest"],
+            capture_output=True,
+            text=True,
+            timeout=600,
+        )
+    except subprocess.TimeoutExpired:
+        return False, "install timed out"
+
+    if result.returncode == 0:
+        return True, ""
+
+    for line in result.stderr.splitlines():
+        if "ERROR" in line:
+            return False, line.split("ERROR", 1)[1].strip()
+    return False, result.stderr.strip().splitlines()[0] if result.stderr.strip() else "install failed"
+
+
 def main():
     installed_only = "--installed-only" in sys.argv
+    install = "--install" in sys.argv
+    only = [a for a in sys.argv[1:] if not a.startswith("--")]
 
     registry = load_registry()
     installed = get_installed_tools() if installed_only else set()
 
     results: dict[str, dict[str, tuple[bool, str]]] = {}
+    unavailable: dict[str, str] = {}
     shells = ["zsh", "bash", "fish"]
 
-    tools = sorted(registry.keys())
+    tools = [t for t in sorted(registry.keys()) if not only or t in only]
     total = len(tools)
 
-    print(f"Validating {total} tools...\n")
+    print(f"Validating {total} tools{' (installing first)' if install else ''}...\n")
 
     for i, tool in enumerate(tools, 1):
         provider, completions = registry[tool]
         if installed_only and provider not in installed:
             continue
 
+        print(f"[{i}/{total}] {tool}...", end=" ", flush=True)
+
+        if install:
+            ok, reason = install_tool(provider)
+            if not ok:
+                # Not installable here, so the entry is untested rather than wrong.
+                unavailable[tool] = reason
+                print("skipped (not installable)")
+                continue
+
         requires = completions.get("requires")
         results[tool] = {}
-
-        print(f"[{i}/{total}] {tool}...", end=" ", flush=True)
         tool_ok = True
 
         for shell in shells:
@@ -161,12 +193,7 @@ def main():
                 results[tool][shell] = (False, str(e))
                 tool_ok = False
 
-        print("✓" if tool_ok else "✗")
-
-    # Summary
-    print("\n" + "=" * 60)
-    print("SUMMARY")
-    print("=" * 60)
+        print("\u2713" if tool_ok else "\u2717")
 
     failures: dict[str, list[tuple[str, str, str]]] = {}
     successes = 0
@@ -178,22 +205,30 @@ def main():
             if ok:
                 successes += 1
             else:
-                if tool not in failures:
-                    failures[tool] = []
+                failures.setdefault(tool, [])
                 _, completions = registry[tool]
                 failures[tool].append((shell, completions[shell], err))
 
+    print("\n" + "=" * 60)
+    print("SUMMARY")
+    print("=" * 60)
     print(f"\nPassed: {successes}/{total_tests}")
 
     if failures:
-        print(f"\nFailed tools ({len(failures)}):\n")
+        print(f"\n## Broken entries ({len(failures)})\n")
         for tool, errs in sorted(failures.items()):
             print(f"  [{tool}]")
             for shell, cmd, err in errs:
-                # Truncate long errors
                 err_short = err[:60] + "..." if len(err) > 60 else err
-                print(f"    {shell}: {err_short}")
+                print(f"    {shell}: `{cmd}` -> {err_short}")
             print()
+
+    if unavailable:
+        # Reported separately: these say nothing about whether the entry is right.
+        print(f"\n## Could not verify ({len(unavailable)})\n")
+        for tool, reason in sorted(unavailable.items()):
+            print(f"  {tool}: {reason[:70]}")
+        print()
 
     return 0 if not failures else 1
 


### PR DESCRIPTION
`validate-registry.py --installed-only` only checks tools that happen to be installed on the machine running it. An entry that is wrong for **everyone** therefore passes CI indefinitely.

The history you asked for makes the case: **eight tools have been removed across the project's life** for not actually supporting completions — fourteen in a single commit (#21) — and every one was found by a person noticing, never by a check. Three more (`gitu`, `gitui`, `mdbook`) turned up by accident in #134 just yesterday. We currently have no idea how many remain.

## What it does

A weekly workflow (plus `workflow_dispatch`) that installs every registry tool and verifies its completion command.

The critical part is that it **separates two different things**:

- **Broken** — the tool installed, but its completion command failed. That's a registry bug, and it fails the run.
- **Could not verify** — the tool wouldn't install on the runner at all. That says nothing about whether the entry is right, so it's reported separately and does **not** fail the run.

Without that split the job would be permanently red from entries like `cargo` and `mise-completions-sync`, which aren't installable mise tools by those names, and everyone would learn to ignore it.

```
$ uv run scripts/validate-registry.py --install cargo mise-completions-sync
[1/2] cargo... skipped (not installable)
[2/2] mise-completions-sync... skipped (not installable)

## Could not verify (2)
  cargo: Failed to install cargo@latest: cargo not found in mise tool registry
  mise-completions-sync: Failed to install mise-completions-sync@latest: ...
```
exit 0 — correctly not a failure.

On a real failure it opens a tracking issue, or comments on the existing one rather than opening a new one every week.

## Details worth noting

- **`cache: false`** on `mise-action`. Caching ~100 tool installs would bloat the cache, and worse, a restored stale install could mask a newly broken entry — defeating the point.
- Only `uv` is installed from `mise.toml` (`install_args: uv`); the audit installs everything else itself.
- Permissions are `contents: read` + `issues: write`, nothing more.
- `--install` accepts tool names to restrict the run, which is how I tested this without installing a hundred tools on my machine.
- 90-minute timeout; `actionlint` clean.

## Also in here

`docs/development.md` documented the **same non-existent registry schema** I fixed in #131 — `[tools.mytool] format = "{bin} completion {shell}"` with a `shells` array. #131 doesn't touch this file, so it's corrected here to the real format, including `requires`, `provided_by` and `bundled`.

## Deliberately not included

Running the audit on PRs that touch `registry.toml`, restricted to changed entries. That would catch bad entries before merge rather than up to a week after, and is the natural follow-up — but it needs diffing the registry between base and head, so it belongs in its own change.