### PR TITLE
fix(registry): correct entries the audit found broken

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -5,7 +5,7 @@ Use this to identify tools that could be added to mise-completions-sync.
 
 ## Supported Tools
 
-Currently **100 tools** have completion support.
+Currently **99 tools** have completion support.
 
 See [docs/tools.md](docs/tools.md) for the full list with shell support details.
 
@@ -66,7 +66,7 @@ These tools are in mise's registry but not yet supported. They may have completi
 | [aws-nuke](https://github.com/ekristen/aws-nuke) | Remove all the resources from an AWS account | Needs testing |
 | [aws-sam](https://github.com/aws/aws-sam-cli) | CLI tool to build, test, debug, and deploy Serv... | Needs testing |
 
-*...and 798 more tools in mise registry*
+*...and 799 more tools in mise registry*
 
 ## Tools Without Completion Support
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -76,3 +76,16 @@ whether the entry is correct.
 
 Run it locally with `mise run audit-registry`. It installs every tool in the
 registry, so expect it to be slow and to leave a lot behind.
+
+A few tools need a working environment — not just an install — before they will
+print a completion script, so the audit can't judge them. `kubeseal` wants a
+reachable cluster config even to emit a static file. Those entries carry
+`audit_skip` with a reason and are reported as unverified rather than broken:
+
+```toml
+kubeseal = { audit_skip = "needs a reachable cluster config even to print completions", zsh = "kubeseal completion zsh" }
+```
+
+Use it sparingly: it silences the only check that would catch the entry going
+stale. `mise run validate-registry` still tests these normally, since a
+developer running it locally usually does have the environment.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -81,7 +81,7 @@ The following tools have shell completion support in mise-completions-sync.
 | [ruff](https://github.com/astral-sh/ruff) | An extremely fast Python linter and code format... | ✓ | ✓ | ✓ |
 | [rumdl](https://github.com/rvben/rumdl) | Markdown Linter and Formatter written in Rust | ✓ | ✓ | ✓ |
 | rustup |  | ✓ | ✓ | ✓ |
-| [saml2aws](https://github.com/Versent/saml2aws) | CLI tool which enables you to login and retriev... | ✓ | ✓ | ✓ |
+| [saml2aws](https://github.com/Versent/saml2aws) | CLI tool which enables you to login and retriev... | ✓ | ✓ |  |
 | [scaleway-cli](https://github.com/scaleway/scaleway-cli) | Command Line Interface for Scaleway | ✓ | ✓ | ✓ |
 | [skaffold](https://github.com/GoogleContainerTools/skaffold) | Easy and Repeatable Kubernetes Development | ✓ | ✓ | ✓ |
 | [sops](https://github.com/getsops/sops) | Simple and flexible tool for managing secrets | ✓ | ✓ |  |
@@ -99,13 +99,12 @@ The following tools have shell completion support in mise-completions-sync.
 | [uv](https://github.com/astral-sh/uv) | An extremely fast Python package installer and ... | ✓ | ✓ | ✓ |
 | uvx |  | ✓ | ✓ | ✓ |
 | [velero](https://github.com/vmware-tanzu/velero) | Backup and migrate Kubernetes applications and ... | ✓ | ✓ | ✓ |
-| vercel | Build and deploy on the Vercel cloud | ✓ | ✓ |  |
 | [watchexec](https://github.com/watchexec/watchexec) | Executes commands in response to file modificat... | ✓ | ✓ | ✓ |
 | [xh](https://github.com/ducaale/xh) | Friendly and fast tool for sending HTTP requests | ✓ | ✓ | ✓ |
 | [yq](https://github.com/mikefarah/yq) | yq is a portable command-line YAML processor | ✓ | ✓ | ✓ |
 | [zellij](https://github.com/zellij-org/zellij) | A terminal workspace with batteries included | ✓ | ✓ | ✓ |
 
-**Total: 100 tools**
+**Total: 99 tools**
 
 ## Shell Support Legend
 

--- a/registry.toml
+++ b/registry.toml
@@ -38,7 +38,7 @@ argocd = "standard"
 istioctl = "standard"
 k3d = "standard"
 ko = "standard"
-kubeseal = "standard"
+kubeseal = { audit_skip = "needs a reachable cluster config even to print completions", zsh = "kubeseal completion zsh", bash = "kubeseal completion bash", fish = "kubeseal completion fish" }
 linkerd = "standard"
 skaffold = "standard"
 stern = "standard"
@@ -70,7 +70,6 @@ ratarmount = "argcomplete"
 # Cloud CLIs
 flyctl = "standard"
 doctl = "standard"
-oci = "standard"
 
 # Container tools
 cosign = "standard"
@@ -101,10 +100,8 @@ hugo = "standard"
 lazygit = "standard"
 lefthook = "standard"
 oc = "standard"
-pitchfork = "standard"
 pulumi = "standard"
 rumdl = "completions"
-saml2aws = "standard"
 step = "standard"
 xh = "generate_complete"
 yq = "standard"
@@ -123,16 +120,21 @@ flux2 = { zsh = "flux completion zsh", bash = "flux completion bash", fish = "fl
 # Partial shell support (zsh + bash)
 npm = { zsh = "npm completion", bash = "npm completion" }
 pnpm = { zsh = "pnpm completion zsh", bash = "pnpm completion bash" }
-vercel = { zsh = "vercel completion zsh", bash = "vercel completion bash" }
 sops = { zsh = "sops completion zsh", bash = "sops completion bash" }
+# oci is click-based: completions come from an env var, not a subcommand.
+oci = { zsh = "env _OCI_COMPLETE=zsh_source oci", bash = "env _OCI_COMPLETE=bash_source oci", fish = "env _OCI_COMPLETE=fish_source oci" }
+
+# saml2aws is kingpin-based: completion comes from flags, and it has no fish support
+saml2aws = { zsh = "saml2aws --completion-script-zsh", bash = "saml2aws --completion-script-bash" }
 
 # Cargo uses rustup
 cargo = { zsh = "rustup completions zsh cargo", bash = "rustup completions bash cargo", fish = "rustup completions fish cargo" }
 
 
-# fnox renders its completions with the `usage` CLI, which is not on PATH inside
-# `mise x fnox` on its own.
+# fnox and pitchfork render their completions with the `usage` CLI, which is not
+# on PATH inside `mise x <tool>` on its own.
 fnox = { requires = "usage", zsh = "fnox completion zsh", bash = "fnox completion bash", fish = "fnox completion fish" }
+pitchfork = { requires = "usage", zsh = "pitchfork completion zsh", bash = "pitchfork completion bash", fish = "pitchfork completion fish" }
 
 prek = { zsh = "prek util generate-shell-completion zsh", bash = "prek util generate-shell-completion bash", fish = "prek util generate-shell-completion fish" }
 

--- a/scripts/validate-registry.py
+++ b/scripts/validate-registry.py
@@ -76,6 +76,10 @@ def load_registry() -> dict[str, tuple[str, dict[str, str]]]:
             # download, not commands, so they are checked differently.
             if entry.get("bundled"):
                 completions["bundled"] = True
+            # Some tools need a working environment (a cluster config, say) even
+            # to print a static script, so the audit cannot judge them.
+            if "audit_skip" in entry:
+                completions["audit_skip"] = entry["audit_skip"]
             expanded[tool_name] = (provider, completions)
 
     return expanded
@@ -160,6 +164,12 @@ def main():
             continue
 
         print(f"[{i}/{total}] {tool}...", end=" ", flush=True)
+
+        skip_reason = completions.get("audit_skip")
+        if install and skip_reason:
+            unavailable[tool] = f"skipped: {skip_reason}"
+            print("skipped (cannot be audited)")
+            continue
 
         if install:
             ok, reason = install_tool(provider)

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -251,6 +251,41 @@ mod tests {
     }
 
     #[test]
+    fn test_pitchfork_requires_usage() {
+        // Regression: pitchfork renders through `usage`, like fnox, so the bare
+        // `standard` pattern failed with "No version is set for shim: usage".
+        let registry = load_registry().expect("Failed to load registry");
+        let pitchfork = registry
+            .tools
+            .get("pitchfork")
+            .expect("pitchfork should be in registry");
+        assert_eq!(pitchfork.completions.requires.as_deref(), Some("usage"));
+    }
+
+    #[test]
+    fn test_saml2aws_uses_completion_flags() {
+        // Regression: saml2aws is kingpin-based and has no `completion` command.
+        let registry = load_registry().expect("Failed to load registry");
+        let saml2aws = registry
+            .tools
+            .get("saml2aws")
+            .expect("saml2aws should be in registry");
+        assert_eq!(
+            saml2aws.completions.zsh.as_deref(),
+            Some("saml2aws --completion-script-zsh")
+        );
+        // kingpin has no fish support
+        assert_eq!(saml2aws.completions.fish, None);
+    }
+
+    #[test]
+    fn test_vercel_removed() {
+        // vercel dropped its `completion` command; nothing replaced it.
+        let registry = load_registry().expect("Failed to load registry");
+        assert!(!registry.tools.contains_key("vercel"));
+    }
+
+    #[test]
     fn test_hyperfine_is_bundled() {
         // hyperfine ships completion files in its download rather than having a
         // command, so the per-shell values are filenames to find, not commands.


### PR DESCRIPTION
The first run of the audit from #138 found **five broken entries** (#140). It paid for itself in four minutes.

| tool | what was wrong | fix |
|---|---|---|
| `pitchfork` | renders through `usage`, like `fnox` | `requires = "usage"` |
| `saml2aws` | kingpin-based, no `completion` command | `--completion-script-{zsh,bash}`, no fish |
| `oci` | click-based, no `completion` subcommand | `env _OCI_COMPLETE=<shell>_source oci` |
| `vercel` | dropped `completion` upstream, nothing replaced it | removed |
| `kubeseal` | wants a reachable cluster to print a static script | `audit_skip` — see below |

Every fix verified against the real binary.

## Two things I'd have got wrong without testing

**`oci` bash.** It failed locally with `Shell completion is not supported for Bash versions older than 4.4` — that's macOS shipping bash 3.2, not a broken entry. I nearly dropped bash support over an artifact of my own machine. It works on Linux, and anywhere bash completions are actually usable.

**`env`.** The obvious `_OCI_COMPLETE=zsh_source oci` doesn't work, because `mise x -- ` execs directly rather than through a shell, so mise treats the assignment as the program name:

```
mise ERROR "_OCI_COMPLETE=zsh_source" couldn't exec process
```

`env` fixes it without nested quoting inside the TOML.

## kubeseal, and a new `audit_skip`

`kubeseal completion zsh` fails with `invalid configuration: no configuration has been provided` — and not only on the runner. With a kubeconfig present it gets as far as prompting for credentials. It genuinely requires cluster auth to emit a static script, which looks like an upstream bug.

That leaves the entry possibly correct for anyone with a working cluster, but permanently unverifiable by the audit. Removing it would break those users; leaving it would make the audit red every week, and a permanently-red audit is one nobody reads — the exact failure mode I argued against in #138.

So an entry can now carry `audit_skip` with a reason, and is reported as unverified rather than broken:

```
## Could not verify (1)
  kubeseal: skipped: needs a reachable cluster config even to print completions
```

It applies **only** to the audit. `mise run validate-registry` still tests these normally, since a developer running it locally usually does have the environment. Documented in `development.md` with an explicit warning that it silences the only check that would catch the entry going stale.

## Verified

66 tests (three new regressions: pitchfork's `requires`, saml2aws' flags and absent fish, vercel's absence), clippy and fmt clean, docs regenerated — 99 tools.

Closes #140 once the next audit run is clean.