### PR TITLE
docs: point at the canonical docs domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 </p>
 
 <p align="center">
-  <a href="https://alltuner.github.io/mise-completions-sync/">Docs</a> &middot;
+  <a href="https://mise-completions.alltuner.com/">Docs</a> &middot;
   <a href="https://alltuner.com/sponsor">Sponsor</a>
 </p>
 
@@ -185,7 +185,7 @@ mise use -g github:alltuner/mise-completions-sync@0.5.1
 
 ## Documentation
 
-Full docs at [alltuner.github.io/mise-completions-sync](https://alltuner.github.io/mise-completions-sync/) — supported tools, completion details, and troubleshooting.
+Full docs at [mise-completions.alltuner.com](https://mise-completions.alltuner.com/) — supported tools, completion details, and troubleshooting.
 
 ## License
 
@@ -193,7 +193,7 @@ Full docs at [alltuner.github.io/mise-completions-sync](https://alltuner.github.
 
 ## Support the project
 
-mise-completions-sync is an open source project built by [David Poblador i Garcia](https://davidpoblador.com/) through [All Tuner Labs](https://www.alltuner.com/).
+mise-completions-sync is an open source project built by [David Poblador i Garcia](https://davidpoblador.com/) through [All Tuner Labs](https://alltuner.com/).
 
 If this project was useful to you, [consider supporting its development](https://alltuner.com/sponsor).
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: mise-completions-sync
 site_description: Automatically sync shell completions for tools managed by mise
-site_url: https://alltuner.github.io/mise-completions-sync/
+site_url: https://mise-completions.alltuner.com/
 site_author: All Tuner Labs, S.L.
 
 repo_url: https://github.com/alltuner/mise-completions-sync


### PR DESCRIPTION
`https://alltuner.github.io/mise-completions-sync/` 301s to `mise-completions.alltuner.com`. Three references, and the least visible one mattered most.

- **`mkdocs.yml:3`** — `site_url`. This feeds the canonical `<link>` tags and the sitemap, so the published site was telling search engines its canonical home is a domain that redirects away.
- **`README.md:11`** — header nav "Docs" link.
- **`README.md:188`** — the link *and* its display text, so it read wrong even unclicked.

Also `README.md:196` used `https://www.alltuner.com/`, which 301s to the apex domain.

**One trap:** the Pages URL redirects to `http://mise-completions.alltuner.com/`, not https. Copying the redirect target verbatim would have baked in a second hop. The https form serves 200 directly.

Verified in the generated output rather than just the config:

```
$ mkdocs build
$ grep canonical site/index.html
rel="canonical" href="https://mise-completions.alltuner.com/"
$ grep loc site/sitemap.xml
<loc>https://mise-completions.alltuner.com/</loc>
<loc>https://mise-completions.alltuner.com/development/</loc>
```

Every remaining link in both files returns 200. The one exception is `alltuner.com/sponsor` → `/sponsor/`, which is just trailing-slash normalisation on our own server; left alone.