### PR TITLE
feat(registry): add yazi

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -117,10 +117,12 @@ The following tools have shell completion support in mise-completions-sync.
 | [watchexec](https://github.com/watchexec/watchexec) | Executes commands in response to file modificat... | ✓ | ✓ | ✓ |
 | whosthere |  | ✓ | ✓ | ✓ |
 | [xh](https://github.com/ducaale/xh) | Friendly and fast tool for sending HTTP requests | ✓ | ✓ | ✓ |
+| ya |  | ✓ | ✓ | ✓ |
+| [yazi](https://github.com/sxyazi/yazi) | Blazing fast terminal file manager written in R... | ✓ | ✓ | ✓ |
 | [yq](https://github.com/mikefarah/yq) | yq is a portable command-line YAML processor | ✓ | ✓ | ✓ |
 | [zellij](https://github.com/zellij-org/zellij) | A terminal workspace with batteries included | ✓ | ✓ | ✓ |
 
-**Total: 115 tools**
+**Total: 117 tools**
 
 ## Shell Support Legend
 

--- a/registry.toml
+++ b/registry.toml
@@ -161,6 +161,8 @@ prek = { zsh = "prek util generate-shell-completion zsh", bash = "prek util gene
 # them. The per-shell value is the filename to look for, not a command.
 hyperfine = { bundled = true, zsh = "_hyperfine", bash = "hyperfine.bash", fish = "hyperfine.fish" }
 killport = { bundled = true, zsh = "_killport", bash = "killport.bash", fish = "killport.fish" }
+yazi = { bundled = true, zsh = "_yazi", bash = "yazi.bash", fish = "yazi.fish" }
+ya = { provided_by = "yazi", bundled = true, zsh = "_ya", bash = "ya.bash", fish = "ya.fish" }
 
 # Unique command patterns
 task = { zsh = "task --completion zsh", bash = "task --completion bash", fish = "task --completion fish" }


### PR DESCRIPTION
Yazi: https://yazi-rs.github.io/
`ya`: https://yazi-rs.github.io/docs/cli#pm

There doesn't seem to be anything explicitly in the docs about shell completions, but the mise tool currently includes them under `$(mise where yazi)/yazi-x86_64-unknown-linux-musl/completions`.