### PR TITLE
feat: add --children for companion binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ misecompsync --shell zsh
 # Sync specific tools
 misecompsync kubectl helm
 
+# Sync a tool and its direct companion binaries
+misecompsync --children uv
+
 # List supported tools
 misecompsync list
 
@@ -93,6 +96,17 @@ misecompsync --current  # or -c
 * `--global` and `--local` are mutually exclusive (same as `mise ls`)
 * Scope flags also apply to `clean` — **caution**: `misecompsync --global clean` would remove completions for tools _not_ in the global config, which may include locally-installed tools if they both use the same `MISE_COMPLETIONS_SYNC_HOME`.
 * Scope flags conflict with explicit tool args and `--new-only`
+
+### Companion binaries
+
+By default, explicitly named tools are parent-only: `misecompsync uv` syncs
+only `uv`. Use `misecompsync --children uv` to also sync direct companion
+binaries that the registry identifies as provided by `uv`. Expansion is
+downward and one hop only. With multiple explicit tools, misecompsync syncs
+the sorted, deduplicated union of those tools and their direct children.
+
+Automatic sync and `--new-only` are unchanged: they include a companion binary
+when its provider is installed.
 
 ### Automatic sync
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -174,6 +174,9 @@ misecompsync --shell zsh
 # Sync specific tool(s)
 misecompsync kubectl helm
 
+# Sync a tool and its direct companion binaries
+misecompsync --children uv
+
 # List tools with completion support
 misecompsync list
 
@@ -203,6 +206,17 @@ misecompsync --current  # or -c
 * `--global` and `--local` are mutually exclusive (same as `mise ls`)
 * Scope flags also apply to `clean` — **caution**: `misecompsync --global clean` would remove completions for tools _not_ in the global config, which may include locally-installed tools if they both use the same `MISE_COMPLETIONS_SYNC_HOME`.
 * Scope flags conflict with explicit tool args and `--new-only`
+
+### Companion binaries
+
+By default, explicitly named tools are parent-only: `misecompsync uv` syncs
+only `uv`. Use `misecompsync --children uv` to also sync direct companion
+binaries that the registry identifies as provided by `uv`. Expansion is
+downward and one hop only. With multiple explicit tools, misecompsync syncs
+the sorted, deduplicated union of those tools and their direct children.
+
+Automatic sync and `--new-only` are unchanged: they include a companion binary
+when its provider is installed.
 
 ## License
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -173,5 +173,10 @@ uvx = { provided_by = "uv", zsh = "uvx --generate-shell-completion zsh", bash = 
 ```
 
 `provided_by` is a one-hop link and is supported only on explicit entries.
-Normal sync and `--new-only` include the child when its provider is installed.
-`misecompsync uvx` syncs only `uvx`; `misecompsync uv` does not expand children.
+By default, explicitly named tools are parent-only: `misecompsync uv`
+syncs only `uv`. Use `misecompsync --children uv` to add direct companion
+binaries provided by `uv`. Expansion is downward and one hop only.
+With multiple explicit tools, misecompsync syncs the sorted, deduplicated
+union of those tools and their direct children.
+Automatic sync and `--new-only` are unchanged: they include a child when
+its provider is installed.

--- a/scripts/generate-tools-docs.py
+++ b/scripts/generate-tools-docs.py
@@ -155,8 +155,13 @@ def main():
     print("```")
     print()
     print("`provided_by` is a one-hop link and is supported only on explicit entries.")
-    print("Normal sync and `--new-only` include the child when its provider is installed.")
-    print("`misecompsync uvx` syncs only `uvx`; `misecompsync uv` does not expand children.")
+    print("By default, explicitly named tools are parent-only: `misecompsync uv`")
+    print("syncs only `uv`. Use `misecompsync --children uv` to add direct companion")
+    print("binaries provided by `uv`. Expansion is downward and one hop only.")
+    print("With multiple explicit tools, misecompsync syncs the sorted, deduplicated")
+    print("union of those tools and their direct children.")
+    print("Automatic sync and `--new-only` are unchanged: they include a child when")
+    print("its provider is installed.")
 
 
 if __name__ == "__main__":

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,10 @@ struct Cli {
     #[arg(value_name = "TOOL")]
     tools: Vec<String>,
 
+    /// Include registry children provided by explicitly named tools
+    #[arg(long, requires = "tools")]
+    children: bool,
+
     /// Only sync completions for newly installed/updated tools (reads MISE_INSTALLED_TOOLS env var)
     #[arg(long, conflicts_with_all = ["tools", "global", "local", "current"])]
     new_only: bool,
@@ -97,7 +101,14 @@ fn run() -> Result<(), sync::Error> {
             let shells = cli
                 .shell
                 .unwrap_or_else(|| vec!["zsh".to_string(), "bash".to_string(), "fish".to_string()]);
-            sync::sync_completions(&dirs, &shells, &cli.tools, flags, cli.new_only)
+            sync::sync_completions(
+                &dirs,
+                &shells,
+                &cli.tools,
+                flags,
+                cli.new_only,
+                cli.children,
+            )
         }
     }
 }
@@ -154,7 +165,17 @@ mod tests {
         assert!(!cli.global);
         assert!(!cli.local);
         assert!(!cli.current);
+        assert!(!cli.children);
         assert!(cli.tools.is_empty());
+    }
+
+    #[test]
+    fn test_children_requires_specific_tools() {
+        let cli = parse(&["misecompsync", "--children", "uv"]).unwrap();
+        assert!(cli.children);
+        assert_eq!(cli.tools, ["uv"]);
+
+        assert!(parse(&["misecompsync", "--children"]).is_err());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,6 +64,13 @@ enum Commands {
     },
 }
 
+fn format_list_entry(tool: &str, provided_by: Option<&str>) -> String {
+    match provided_by {
+        Some(provider) => format!("{tool} (provided by {provider})"),
+        None => tool.to_string(),
+    }
+}
+
 fn main() {
     if let Err(e) = run() {
         eprintln!("error: {e}");
@@ -80,8 +87,11 @@ fn run() -> Result<(), sync::Error> {
         Some(Commands::List) => {
             let registry = registry::load_registry()?;
             println!("Tools with completion support:");
-            for tool in registry.tools.keys() {
-                println!("  {tool}");
+            for (tool, entry) in &registry.tools {
+                println!(
+                    "  {}",
+                    format_list_entry(tool, entry.provided_by.as_deref())
+                );
             }
             Ok(())
         }
@@ -119,6 +129,16 @@ mod tests {
 
     fn parse(args: &[&str]) -> Result<Cli, clap::Error> {
         Cli::try_parse_from(args)
+    }
+
+    #[test]
+    fn test_list_formatting_keeps_ordinary_entry_unchanged() {
+        assert_eq!(format_list_entry("kubectl", None), "kubectl");
+    }
+
+    #[test]
+    fn test_list_formatting_annotates_companion_entry_with_provider() {
+        assert_eq!(format_list_entry("uvx", Some("uv")), "uvx (provided by uv)");
     }
 
     #[test]

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -349,22 +349,26 @@ fn installed_sync_targets(
 fn specific_sync_targets(
     registry: &registry::Registry,
     specific_tools: &[String],
+    include_children: bool,
 ) -> Vec<SyncTarget> {
-    let mut targets: Vec<_> = specific_tools
+    let is_requested = |tool_name: &str| specific_tools.iter().any(|tool| tool == tool_name);
+    let mut targets: Vec<_> = registry
+        .tools
         .iter()
-        .filter_map(|tool_name| {
-            registry.tools.get(tool_name).map(|entry| SyncTarget {
-                tool_name: tool_name.clone(),
-                tool_id: entry
-                    .provided_by
-                    .as_deref()
-                    .unwrap_or(tool_name)
-                    .to_string(),
-            })
+        .filter(|(tool_name, entry)| {
+            is_requested(tool_name)
+                || (include_children && entry.provided_by.as_deref().is_some_and(is_requested))
+        })
+        .map(|(tool_name, entry)| SyncTarget {
+            tool_name: tool_name.clone(),
+            tool_id: entry
+                .provided_by
+                .as_deref()
+                .unwrap_or(tool_name)
+                .to_string(),
         })
         .collect();
     targets.sort_by(|a, b| a.tool_name.cmp(&b.tool_name));
-    targets.dedup_by(|a, b| a.tool_name == b.tool_name);
     targets
 }
 
@@ -511,6 +515,7 @@ pub fn sync_completions(
     specific_tools: &[String],
     flags: MiseLsFlags,
     new_only: bool,
+    include_children: bool,
 ) -> Result<(), Error> {
     let registry = registry::load_registry()?;
 
@@ -525,7 +530,7 @@ pub fn sync_completions(
         };
         installed_sync_targets(&registry, &tools_map)
     } else {
-        specific_sync_targets(&registry, specific_tools)
+        specific_sync_targets(&registry, specific_tools, include_children)
     };
 
     if tools_in_registry.is_empty() {
@@ -683,31 +688,34 @@ mod tests {
         }
     }
 
-    fn registry_with_provider() -> registry::Registry {
-        let completions = || registry::ToolCompletions {
-            zsh: Some("completion zsh".to_string()),
-            bash: None,
-            fish: None,
-            requires: None,
-            bundled: None,
-        };
+    fn test_tool_entry(provided_by: Option<&str>) -> registry::ToolEntry {
+        registry::ToolEntry {
+            completions: registry::ToolCompletions {
+                zsh: Some("completion zsh".to_string()),
+                bash: None,
+                fish: None,
+                requires: None,
+                bundled: None,
+            },
+            provided_by: provided_by.map(str::to_string),
+        }
+    }
 
+    fn expected_targets(targets: &[(&str, &str)]) -> Vec<SyncTarget> {
+        targets
+            .iter()
+            .map(|(tool_name, tool_id)| SyncTarget {
+                tool_name: (*tool_name).to_string(),
+                tool_id: (*tool_id).to_string(),
+            })
+            .collect()
+    }
+
+    fn registry_with_provider() -> registry::Registry {
         registry::Registry {
             tools: HashMap::from([
-                (
-                    "uv".to_string(),
-                    registry::ToolEntry {
-                        completions: completions(),
-                        provided_by: None,
-                    },
-                ),
-                (
-                    "uvx".to_string(),
-                    registry::ToolEntry {
-                        completions: completions(),
-                        provided_by: Some("uv".to_string()),
-                    },
-                ),
+                ("uv".to_string(), test_tool_entry(None)),
+                ("uvx".to_string(), test_tool_entry(Some("uv"))),
             ]),
         }
     }
@@ -1062,22 +1070,63 @@ mod tests {
     }
 
     #[test]
-    fn test_specific_sync_targets_do_not_expand_provider() {
+    fn test_specific_sync_targets_do_not_expand_provider_by_default() {
         let registry = registry_with_provider();
 
         assert_eq!(
-            specific_sync_targets(&registry, &["uvx".to_string(), "uvx".to_string()]),
-            vec![SyncTarget {
-                tool_name: "uvx".to_string(),
-                tool_id: "uv".to_string(),
-            }]
+            specific_sync_targets(&registry, &["uvx".to_string(), "uvx".to_string()], false,),
+            expected_targets(&[("uvx", "uv")])
         );
         assert_eq!(
-            specific_sync_targets(&registry, &["uv".to_string()]),
-            vec![SyncTarget {
-                tool_name: "uv".to_string(),
-                tool_id: "uv".to_string(),
-            }]
+            specific_sync_targets(&registry, &["uv".to_string()], false),
+            expected_targets(&[("uv", "uv")])
+        );
+    }
+
+    #[test]
+    fn test_specific_sync_targets_expand_only_direct_children() {
+        let mut registry = registry_with_provider();
+        registry
+            .tools
+            .insert("uv-tool".to_string(), test_tool_entry(Some("uvx")));
+
+        assert_eq!(
+            specific_sync_targets(&registry, &["uv".to_string()], true),
+            expected_targets(&[("uv", "uv"), ("uvx", "uv")])
+        );
+
+        assert_eq!(
+            specific_sync_targets(&registry, &["uvx".to_string()], true),
+            expected_targets(&[("uv-tool", "uvx"), ("uvx", "uv")])
+        );
+    }
+
+    #[test]
+    fn test_specific_sync_targets_expand_a_sorted_deduplicated_union() {
+        let mut registry = registry_with_provider();
+        registry
+            .tools
+            .insert("uv-tool".to_string(), test_tool_entry(Some("uvx")));
+
+        assert_eq!(
+            specific_sync_targets(
+                &registry,
+                &["uvx".to_string(), "uv".to_string(), "uv".to_string()],
+                true,
+            ),
+            expected_targets(&[("uv", "uv"), ("uv-tool", "uvx"), ("uvx", "uv")])
+        );
+    }
+
+    #[test]
+    fn test_specific_sync_targets_expand_children_of_unregistered_provider() {
+        let registry = registry::Registry {
+            tools: HashMap::from([("uvx".to_string(), test_tool_entry(Some("uv")))]),
+        };
+
+        assert_eq!(
+            specific_sync_targets(&registry, &["uv".to_string()], true),
+            expected_targets(&[("uvx", "uv")])
         );
     }
 


### PR DESCRIPTION
## Summary

- add an opt-in `--children` flag for explicit tool selection
- include direct `provided_by` entries without changing existing parent-only behavior
- show companion relationships in `misecompsync list` and document the selection rules

## Behavior

`misecompsync uv` continues to sync only `uv`. `misecompsync --children uv` syncs `uv` plus direct registry entries provided by it, such as `uvx`. Expansion is downward and one hop only; multiple inputs produce a sorted, deduplicated union. Bare sync and `--new-only` keep their existing provider-aware behavior.

## Validation

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo build --release`
- `cargo test` (73 passed)
- `python3 scripts/check-docs-sync.py`
- `git diff --check upstream/main...HEAD`

Closes #145
